### PR TITLE
Make Travis launch test only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - master
 install:
 - npm run bootstrap
-after_success: npm run coveralls
+after_script: npm run coveralls
 language: node_js
 sudo: false
 node_js:

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,7 @@ module.exports = {
         '**/?(*.)+(spec|test).[tj]s?(x)',
     ],
     testPathIgnorePatterns: ['/node_modules/', 'locals.js', 'testOne.js', 'testAll.js'],
+    collectCoverage: true,
     coveragePathIgnorePatterns: ['/node_modules/', '/test/', '/lib/', '/lodex/src/reducers/'],
+    coverageReporters: ['lcov', 'text-summary'],
 };

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "doc": "lerna run doc",
     "lint": "lerna run --no-bail lint",
     "test": "jest",
-    "test:coverage": "jest --coverage",
-    "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls"
+    "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
The `after_success` phase implied to re-run the tests entirely.
This way, it is no more the case.

See <https://medium.com/javascript-in-plain-english/add-test-coverage-to-vue-js-app-with-jest-travis-ci-and-coveralls-d10d118125c2#314a>.