### PR TITLE
Improve istex test code coverage

### DIFF
--- a/packages/istex/src/files-content.js
+++ b/packages/istex/src/files-content.js
@@ -23,9 +23,8 @@ function ISTEXFilesContent(data, feed) {
         headers.Authorization = `Bearer ${token}`;
     }
     if (!data.source) {
-        throw new Error(
-            '[ISTEXFiles] should be defined'
-            + ' before this statement.',
+        return feed.stop(
+            new Error('[ISTEXFiles] should be used before this statement.'),
         );
     }
     const options = {


### PR DESCRIPTION
for ISTEXFiles, ISTEXFilesContent, and ISTEXFacet.

Strange that usual method did not make code coverage useful for those.

Remove the downloaded PDF.

Use `import` instead of `require`.