### PR TITLE
docs(conditor): Make unwanted parts of the doc @private

### DIFF
--- a/docs/plugin-conditor.md
+++ b/docs/plugin-conditor.md
@@ -52,36 +52,9 @@ Sachant qu'on appauvrit (casse, accents, tiret, apostrophe) tous les champs.
 
 #### Table of Contents
 
--   [RNSR](#rnsr)
--   [RNSR](#rnsr-1)
--   [loadedRNSR](#loadedrnsr)
--   [getRnsrYear](#getrnsryear)
 -   [compareRnsr](#comparernsr)
 -   [conditorScroll](#conditorscroll)
 -   [affAlign](#affalign)
--   [xPublicationYears](#xpublicationyears)
-
-### RNSR
-
-### RNSR
-
-Type: [RNSR](#rnsr)
-
-### loadedRNSR
-
-Cache the different years of RNSR
-
-Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), [RNSR](#rnsr)>
-
-### getRnsrYear
-
-Get the RNSR of year
-
-#### Parameters
-
--   `year` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 4 digits year of RNSR to load
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;([RNSR](#rnsr) | null)>** 
 
 ### compareRnsr
 
@@ -215,5 +188,3 @@ Output:
 #### Parameters
 
 -   `year` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Year of the RNSR to use instead of the last one
-
-### xPublicationYears

--- a/docs/plugin-core.md
+++ b/docs/plugin-core.md
@@ -16,7 +16,6 @@ npm install @ezs/core
 
 -   [pack](#pack)
 -   [unpack](#unpack)
--   [exec](#exec)
 -   [tracer](#tracer)
 -   [debug](#debug)
 -   [env](#env)
@@ -55,17 +54,6 @@ Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 Take `String` and throw `Object` builded by JSON.parse on each line
 
 Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### exec
-
-Take `Object` and delegate processing to an external programme
-
-#### Parameters
-
--   `token` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Value of EZS_TOKEN (for security)
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### tracer
 

--- a/packages/conditor/README.md
+++ b/packages/conditor/README.md
@@ -52,36 +52,9 @@ Sachant qu'on appauvrit (casse, accents, tiret, apostrophe) tous les champs.
 
 #### Table of Contents
 
--   [RNSR](#rnsr)
--   [RNSR](#rnsr-1)
--   [loadedRNSR](#loadedrnsr)
--   [getRnsrYear](#getrnsryear)
 -   [compareRnsr](#comparernsr)
 -   [conditorScroll](#conditorscroll)
 -   [affAlign](#affalign)
--   [xPublicationYears](#xpublicationyears)
-
-### RNSR
-
-### RNSR
-
-Type: [RNSR](#rnsr)
-
-### loadedRNSR
-
-Cache the different years of RNSR
-
-Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), [RNSR](#rnsr)>
-
-### getRnsrYear
-
-Get the RNSR of year
-
-#### Parameters
-
--   `year` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 4 digits year of RNSR to load
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;([RNSR](#rnsr) | null)>** 
 
 ### compareRnsr
 
@@ -215,5 +188,3 @@ Output:
 #### Parameters
 
 -   `year` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Year of the RNSR to use instead of the last one
-
-### xPublicationYears

--- a/packages/conditor/src/affAlign.js
+++ b/packages/conditor/src/affAlign.js
@@ -4,14 +4,15 @@ import { any, pipe, slice } from 'ramda';
 import { isIn } from './rnsr';
 import { depleteString } from './strings';
 
-/** @typedef {import('./rnsr').RepNatStrRech} RNSR */
+/** @private @typedef {import('./rnsr').RepNatStrRech} RNSR */
 
-/** @type {RNSR} */
+/** @private @type {RNSR} */
 let RNSR;
 
 /**
  * Cache the different years of RNSR
  * @type {Object<number,RNSR>}
+ * @private
  */
 const loadedRNSR = {};
 
@@ -19,6 +20,7 @@ const loadedRNSR = {};
  * Get the RNSR of year
  * @param {number}  year    4 digits year of RNSR to load
  * @returns {Promise<RNSR|null>}
+ * @private
  */
 const getRnsrYear = async (year) => {
     if (loadedRNSR[year]) return loadedRNSR[year];
@@ -154,7 +156,7 @@ export default async function affAlign(data, feed) {
         return feed.send(new Error('affAlign: notice should have authors'));
     }
     const xPublicationDate = data.xPublicationDate || [];
-    /** @type number[] */
+    /** @private @type number[] */
     const xPublicationYears = xPublicationDate.map(getYear);
     const authors = data.authors.reduce(addRnsrFromYearsInAuthor(xPublicationYears), []);
     const notice = { ...data, authors };

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,7 +16,6 @@ npm install @ezs/core
 
 -   [pack](#pack)
 -   [unpack](#unpack)
--   [exec](#exec)
 -   [tracer](#tracer)
 -   [debug](#debug)
 -   [env](#env)
@@ -55,17 +54,6 @@ Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 Take `String` and throw `Object` builded by JSON.parse on each line
 
 Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### exec
-
-Take `Object` and delegate processing to an external programme
-
-#### Parameters
-
--   `token` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Value of EZS_TOKEN (for security)
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### tracer
 


### PR DESCRIPTION
Add @private to JSDoc comments.

I don't understand why `exec` is removed from `@ezs/core` markdowns.