### PR TITLE
Fix ezs/sparql tests

### DIFF
--- a/packages/sparql/test/query.spec.js
+++ b/packages/sparql/test/query.spec.js
@@ -1,9 +1,13 @@
 import assert from 'assert';
+import fetch from 'fetch-with-proxy';
 import from from 'from';
+// @ts-ignore
 import ezs from '../../core/src';
 import statements from '../src';
 
 ezs.use(statements);
+
+jest.mock('fetch-with-proxy');
 
 test('get an error when empty query', (done) => {
     from([{ query: '', endpoint: 'https://data.istex.fr/sparql/' }])
@@ -32,6 +36,10 @@ test('get an error when empty SPQARQL endpoint', (done) => {
 });
 
 test('get an error when incorrect SPARQL endpoint', (done) => {
+    // @ts-ignore
+    fetch.mockResolvedValue({
+        ok: false,
+    });
     from([{ query: 'SELECT * WHERE { ?subject ?verb ?complement . } LIMIT 100', endpoint: 'https://data.istex.fr/spa' }])
         .pipe(ezs('SPARQLQuery'))
         .pipe(ezs.catch((e) => e))
@@ -46,6 +54,15 @@ test('get an error when incorrect SPARQL endpoint', (done) => {
 });
 
 test('verify format response is in json', (done) => {
+    // @ts-ignore
+    fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+            results: {
+                bindings: new Array(100),
+            },
+        }),
+    });
     from([{ query: 'SELECT * WHERE { ?subject ?verb ?complement . } LIMIT 100', endpoint: 'https://data.istex.fr/sparql/' }])
         .pipe(ezs('SPARQLQuery'))
         .pipe(ezs.catch((e) => e))


### PR DESCRIPTION
Because they fail sometimes, due to timeout ([example](https://github.com/Inist-CNRS/ezs/runs/2389390019?check_suite_focus=true))

Let's use [Jest's module's mocking](https://jestjs.io/docs/mock-functions#mocking-modules).
