### PR TITLE
Fix @ezs/conditor 2.2.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
     "js/ts.implicitProjectConfig.checkJs": true,
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "editor.formatOnSave": true,
 }

--- a/packages/conditor/.npmignore
+++ b/packages/conditor/.npmignore
@@ -5,4 +5,4 @@
 # White list only the required files
 !lib/**/*
 !bin/*
-!data/RNSR.json
+!data/RNSR*.json


### PR DESCRIPTION
RNSR files are no longer ignored.

Error was:

```error
ENOENT: no such file or directory, open '.../node_modules/@ezs/conditor/data/RNSR-2020.json'
```