### PR TITLE
Sort statements in documentation

### DIFF
--- a/docs/plugin-analytics.md
+++ b/docs/plugin-analytics.md
@@ -21,15 +21,15 @@ npm install @ezs/analytics
 -   [files](#files)
 -   [buffers](#buffers)
 -   [maximizing](#maximizing)
+-   [bufferize](#bufferize)
 -   [groupingByModulo](#groupingbymodulo)
 -   [reducing](#reducing)
--   [bufferize](#bufferize)
 -   [aggregate](#aggregate)
 -   [slice](#slice)
+-   [distinct](#distinct)
+-   [exploding](#exploding)
 -   [graph](#graph)
 -   [upload](#upload)
--   [exploding](#exploding)
--   [distinct](#distinct)
 -   [pair](#pair)
 -   [merging](#merging)
 -   [summing](#summing)
@@ -38,19 +38,19 @@ npm install @ezs/analytics
 -   [greater](#greater)
 -   [pluck](#pluck)
 -   [drop](#drop)
--   [groupingByLevenshtein](#groupingbylevenshtein)
 -   [groupingByHamming](#groupingbyhamming)
+-   [groupingByLevenshtein](#groupingbylevenshtein)
 -   [keys](#keys)
--   [tune](#tune)
 -   [groupingByEquality](#groupingbyequality)
+-   [tune](#tune)
 -   [multiply](#multiply)
 -   [less](#less)
 -   [count](#count)
--   [sort](#sort)
 -   [distribute](#distribute)
+-   [sort](#sort)
 -   [combine](#combine)
--   [expand](#expand)
 -   [distance](#distance)
+-   [expand](#expand)
 -   [segment](#segment)
 -   [statistics](#statistics)
 
@@ -243,6 +243,44 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### bufferize
+
+Takes all `Objects` and bufferize them in a store
+
+```json
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[bufferize]
+path = bufferID
+```
+
+Output:
+
+```json
+ [
+          { year: 2000, dept: 54, bufferID: 'AEERRFFF' },
+          { year: 2001, dept: 55, bufferID: 'AEERRFFF' },
+          { year: 2003, dept: 54, bufferID: 'AEERRFFF' },
+ ]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the path to insert the bufferID (optional, default `bufferID`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### groupingByModulo
 
 Take `Object` like `{ id, value }` and reduce all `value`s with the same
@@ -311,44 +349,6 @@ Output:
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### bufferize
-
-Takes all `Objects` and bufferize them in a store
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[bufferize]
-path = bufferID
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: 54, bufferID: 'AEERRFFF' },
-          { year: 2001, dept: 55, bufferID: 'AEERRFFF' },
-          { year: 2003, dept: 54, bufferID: 'AEERRFFF' },
- ]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the path to insert the bufferID (optional, default `bufferID`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -434,6 +434,90 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### distinct
+
+Take `Object` object getting some fields with json path, and do ...
+
+```json
+[{
+          { a: 'x', b: 'z' },
+          { a: 't', b: 'z' },
+          { a: 't', b: 'z' },
+          { a: 'x', b: 'z' },
+          { a: 'x', b: 'z' },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[distinct]
+path = a
+```
+
+Output:
+
+```json
+[
+          { id: 'x', value: 1 },
+          { id: 't', value: 1 },
+          { id: 't', value: 1 },
+          { id: 'x', value: 1 },
+          { id: 'x', value: 1 },
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `"id"`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### exploding
+
+Take `Object` and take values with [value] path (must be an array)
+and throw object of each value. The new object is build with [id] and eac value.
+
+```json
+[
+ { departure: ['tokyo', 'nancy'], arrival: 'toul' },
+ { departure: ['paris', 'nancy'], arrival: 'toul' },
+ { departure: ['london', 'berlin'], arrival: 'toul' },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[exploding]
+```
+
+Output:
+
+```json
+[
+   { "id": "toul", "value": "tokyo" },
+   { "id": "toul", "value": "nancy" },
+   { "id": "toul", "value": "paris" },
+   { "id": "toul", "value": "nancy" },
+   { "id": "toul", "value": "london" },
+   { "id": "toul", "value": "berlin" }
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### graph
 
 Take `Object` and throw a new special object (id, value) for each combination of values
@@ -512,90 +596,6 @@ Output:
 -   `extension` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file extension (optional, default `bin`)
 -   `prefix` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file prefix (optional, default `upload`)
 -   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** TTL in seconds, before cleanup the file (EZS_DELAY) (optional, default `3600`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### exploding
-
-Take `Object` and take values with [value] path (must be an array)
-and throw object of each value. The new object is build with [id] and eac value.
-
-```json
-[
- { departure: ['tokyo', 'nancy'], arrival: 'toul' },
- { departure: ['paris', 'nancy'], arrival: 'toul' },
- { departure: ['london', 'berlin'], arrival: 'toul' },
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[exploding]
-```
-
-Output:
-
-```json
-[
-   { "id": "toul", "value": "tokyo" },
-   { "id": "toul", "value": "nancy" },
-   { "id": "toul", "value": "paris" },
-   { "id": "toul", "value": "nancy" },
-   { "id": "toul", "value": "london" },
-   { "id": "toul", "value": "berlin" }
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### distinct
-
-Take `Object` object getting some fields with json path, and do ...
-
-```json
-[{
-          { a: 'x', b: 'z' },
-          { a: 't', b: 'z' },
-          { a: 't', b: 'z' },
-          { a: 'x', b: 'z' },
-          { a: 'x', b: 'z' },
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[distinct]
-path = a
-```
-
-Output:
-
-```json
-[
-          { id: 'x', value: 1 },
-          { id: 't', value: 1 },
-          { id: 't', value: 1 },
-          { id: 'x', value: 1 },
-          { id: 'x', value: 1 },
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `"id"`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -961,53 +961,6 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### groupingByLevenshtein
-
-Take `Object` like `{ id, value }` and reduce all `value`s with
-`id` which have the same Levenshtein distance in a single object
-
-```json
-[
-   { "id": "lorem", "value": 1 },
-   { "id": "Lorem", "value": 1 },
-   { "id": "loren", "value": 1 },
-   { "id": "korem", "value": 1 },
-   { "id": "olrem", "value": 1 },
-   { "id": "toto", "value": 1 },
-   { "id": "titi", "value": 1 },
-   { "id": "lorem", "value": 1 }
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[groupingByLevenshtein]
-distance = 2
-
-[summing]
-```
-
-Output:
-
-```json
-[
-   { "id": [ "lorem", "Lorem", "loren", "korem", "olrem" ], "value": 6 },
-   { "id": [ "toto", "titi" ], "value": 2 }
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
--   `distance` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** minimal levenshtein distance to have a same id (optional, default `1`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### groupingByHamming
 
 Take `Object` like `{ id, value }` and reduce all `value` with `id` which
@@ -1052,6 +1005,53 @@ Output:
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### groupingByLevenshtein
+
+Take `Object` like `{ id, value }` and reduce all `value`s with
+`id` which have the same Levenshtein distance in a single object
+
+```json
+[
+   { "id": "lorem", "value": 1 },
+   { "id": "Lorem", "value": 1 },
+   { "id": "loren", "value": 1 },
+   { "id": "korem", "value": 1 },
+   { "id": "olrem", "value": 1 },
+   { "id": "toto", "value": 1 },
+   { "id": "titi", "value": 1 },
+   { "id": "lorem", "value": 1 }
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[groupingByLevenshtein]
+distance = 2
+
+[summing]
+```
+
+Output:
+
+```json
+[
+   { "id": [ "lorem", "Lorem", "loren", "korem", "olrem" ], "value": 6 },
+   { "id": [ "toto", "titi" ], "value": 2 }
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `distance` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** minimal levenshtein distance to have a same id (optional, default `1`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1108,37 +1108,6 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### tune
-
-Take all `Object` and sort them with selected field
-
-```json
-[{
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[tune]
-```
-
-Output:
-
-```json
-[
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for the sort key (optional, default `id`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### groupingByEquality
 
 Take `Object` like `{ id, value }` and reduce all values with the same `id`
@@ -1186,6 +1155,37 @@ Output:
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### tune
+
+Take all `Object` and sort them with selected field
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[tune]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for the sort key (optional, default `id`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1360,56 +1360,6 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### sort
-
-Take all `Object` and sort them with dedicated key
-
-```json
-[{
- { id: 2000, value: 1 },
- { id: 2001, value: 2 },
- { id: 2003, value: 3 },
- { id: 2005, value: 4 },
- { id: 2007, value: 5 },
- { id: 2009, value: 6 },
- { id: 2011, value: 7 },
- { id: 2013, value: 8 },
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[sort]
-path = value
-reverse = true
-```
-
-Output:
-
-```json
-[
-{ "id": 2013, "value": 8 },
-{ "id": 2011, "value": 7 },
-{ "id": 2009, "value": 6 },
-{ "id": 2007, "value": 5 },
-{ "id": 2005, "value": 4 },
-{ "id": 2003, "value": 3 },
-{ "id": 2001, "value": 2 },
-{ "id": 2000, "value": 1 }
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `reverse` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** reverser order (optional, default `false`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### distribute
 
 Take `Object` like { id, value } and throw a serie of number value
@@ -1468,6 +1418,56 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### sort
+
+Take all `Object` and sort them with dedicated key
+
+```json
+[{
+ { id: 2000, value: 1 },
+ { id: 2001, value: 2 },
+ { id: 2003, value: 3 },
+ { id: 2005, value: 4 },
+ { id: 2007, value: 5 },
+ { id: 2009, value: 6 },
+ { id: 2011, value: 7 },
+ { id: 2013, value: 8 },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[sort]
+path = value
+reverse = true
+```
+
+Output:
+
+```json
+[
+{ "id": 2013, "value": 8 },
+{ "id": 2011, "value": 7 },
+{ "id": 2009, "value": 6 },
+{ "id": 2007, "value": 5 },
+{ "id": 2005, "value": 4 },
+{ "id": 2003, "value": 3 },
+{ "id": 2001, "value": 2 },
+{ "id": 2000, "value": 1 }
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `reverse` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** reverser order (optional, default `false`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### combine
 
 Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
@@ -1513,53 +1513,6 @@ Output:
 -   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
 -   `persistent` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The internal database will be reused until it is deleted (optional, default `false`)
 -   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### expand
-
-Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
-the internal pipeline receive a special object { id, value } id is the item identifier & value is the item path value
-The internal pipeline can expand value with another
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[expand]
-path = dept
-file = ./departement.ini
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
-          { year: 2001, dept: { id: 55, value: 'Meuse' } },
-          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
- ]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
--   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** How many chunk for sending to the external pipeline (optional, default `1`)
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `cacheName` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Enable cache, with dedicated name
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1634,6 +1587,53 @@ Output:
 #### Parameters
 
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### expand
+
+Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
+the internal pipeline receive a special object { id, value } id is the item identifier & value is the item path value
+The internal pipeline can expand value with another
+
+```json
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[expand]
+path = dept
+file = ./departement.ini
+```
+
+Output:
+
+```json
+ [
+          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
+          { year: 2001, dept: { id: 55, value: 'Meuse' } },
+          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
+ ]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
+-   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** How many chunk for sending to the external pipeline (optional, default `1`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `cacheName` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Enable cache, with dedicated name
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 

--- a/docs/plugin-analytics.md
+++ b/docs/plugin-analytics.md
@@ -16,97 +16,54 @@ npm install @ezs/analytics
 
 #### Table of Contents
 
--   [output](#output)
--   [minimizing](#minimizing)
--   [files](#files)
--   [buffers](#buffers)
--   [maximizing](#maximizing)
--   [bufferize](#bufferize)
--   [groupingByModulo](#groupingbymodulo)
--   [reducing](#reducing)
 -   [aggregate](#aggregate)
--   [slice](#slice)
+-   [bufferize](#bufferize)
+-   [buffers](#buffers)
+-   [combine](#combine)
+-   [count](#count)
+-   [distance](#distance)
 -   [distinct](#distinct)
--   [exploding](#exploding)
--   [graph](#graph)
--   [upload](#upload)
--   [pair](#pair)
--   [merging](#merging)
--   [summing](#summing)
--   [filter](#filter)
--   [value](#value)
--   [greater](#greater)
--   [pluck](#pluck)
+-   [distribute](#distribute)
 -   [drop](#drop)
+-   [expand](#expand)
+-   [exploding](#exploding)
+-   [files](#files)
+-   [filter](#filter)
+-   [graph](#graph)
+-   [greater](#greater)
+-   [groupingByEquality](#groupingbyequality)
 -   [groupingByHamming](#groupingbyhamming)
 -   [groupingByLevenshtein](#groupingbylevenshtein)
+-   [groupingByModulo](#groupingbymodulo)
 -   [keys](#keys)
--   [groupingByEquality](#groupingbyequality)
--   [tune](#tune)
--   [multiply](#multiply)
 -   [less](#less)
--   [count](#count)
--   [distribute](#distribute)
--   [sort](#sort)
--   [combine](#combine)
--   [distance](#distance)
--   [expand](#expand)
+-   [maximizing](#maximizing)
+-   [merging](#merging)
+-   [minimizing](#minimizing)
+-   [multiply](#multiply)
+-   [output](#output)
+-   [pair](#pair)
+-   [pluck](#pluck)
+-   [reducing](#reducing)
 -   [segment](#segment)
+-   [slice](#slice)
+-   [sort](#sort)
 -   [statistics](#statistics)
+-   [summing](#summing)
+-   [tune](#tune)
+-   [upload](#upload)
+-   [value](#value)
 
-### output
+### aggregate
 
-Format the output with data a meta
-
-#### Parameters
-
--   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent or not (optional, default `false`)
--   `meta` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>?** fields to be considered as metadata
-                                      object
-
-#### Examples
-
-Input
-
-
-```javascript
-[
-     { _id: 1, value: 2, total: 2 },
-     { _id: 2, value: 4, total: 2 }
-]
-```
-
-Script
-
-
-```javascript
-.pipe(ezs('output', { meta: 'total' }))
-```
-
-Output
-
-
-```javascript
-{
-    data: [
-        { _id: 1, value: 2 },
-        { _id: 2, value: 4 }
-    ],
-    meta: {
-        total: 2
-    }
-}
-```
-
-Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### minimizing
-
-Take special `Object` like `{id, value}` and replace `value` with the min of
-`value`s
+Aggregate by id and count
 
 ```json
 [{
+         { id: 'x', value: 2 },
+         { id: 't', value: 2 },
+         { id: 'x', value: 3 },
+         { id: 'x', value: 5 },
 }]
 ```
 
@@ -116,130 +73,23 @@ Script:
 [use]
 plugin = analytics
 
-[drop]
+[aggregate]
+path = id
 ```
 
 Output:
 
 ```json
 [
+         { id: 'x', value: [ 2, 3, 5] },
+         { id: 't', value: [ 2 ]  },
 ]
 ```
 
 #### Parameters
 
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### files
-
-Take `Object` containing filename et throw content by chunk
-
-Note : files must be under the working directory of the Node.js process.
-
-```json
-[ fi1e1.csv, file2.csv ]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-plugin = basics
-
-[files]
-[CSVParse]
-```
-
-Output:
-
-```json
-[
-(...)
-]
-```
-
-#### Parameters
-
--   `location` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path location to find files (optional, default `.`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### buffers
-
-Takes all `Objects` from a store
-
-```json
-[
-     'AEERRFFF',
-     'DFERGGGV',
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[buffers]
-from = store/13455666/ddd
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: 54, bufferID: 'AEERRFFF' },
-          { year: 2001, dept: 55, bufferID: 'AEERRFFF' },
-          { annee: 2003, bufferID: 'DFERGGGV' },
- ]
-```
-
-#### Parameters
-
--   `from` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the store id
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### maximizing
-
-Take special `Object` like `{id, value}` and replace `value` with the max of `value`s
-
-```json
-[
-  { id: 'toul', value: [1, 2, 3] },
-  { id: 'nancy', value: [2, 3, 4] },
-  { id: 'neufchateau', value: [3, 4, 5] },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[maximizing]
-```
-
-Output:
-
-```json
-[
-   { "id": "toul", "value": 3 },
-   { "id": "nancy", "value": 4 },
-   { "id": "neufchateau", "value": 5 }
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (if not found 1 is the default value) (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -281,14 +131,15 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### groupingByModulo
+### buffers
 
-Take `Object` like `{ id, value }` and reduce all `value`s with the same
-modulo computation in a ansingle object
+Takes all `Objects` from a store
 
 ```json
-[{
-}]
+[
+     'AEERRFFF',
+     'DFERGGGV',
+]
 ```
 
 Script:
@@ -297,34 +148,37 @@ Script:
 [use]
 plugin = analytics
 
-[groupingByModulo]
+[buffers]
+from = store/13455666/ddd
 ```
 
 Output:
 
 ```json
-[
-]
+ [
+          { year: 2000, dept: 54, bufferID: 'AEERRFFF' },
+          { year: 2001, dept: 55, bufferID: 'AEERRFFF' },
+          { annee: 2003, bufferID: 'DFERGGGV' },
+ ]
 ```
 
 #### Parameters
 
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `from` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the store id
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### reducing
+### combine
 
-Take `Object` group value of `{ id, value }` objectpath
+Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
+the internal pipeline must produce a stream of special object (id, value)
 
 ```json
-[{
-         { id: 'x', value: 2 },
-         { id: 't', value: 2 },
-         { id: 'x', value: 3 },
-         { id: 'x', value: 5 },
-}]
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
 ```
 
 Script:
@@ -333,36 +187,55 @@ Script:
 [use]
 plugin = analytics
 
-[reducing]
+[combine]
+path = dept
+file = ./departement.ini
 ```
 
 Output:
 
 ```json
-[
-         { id: 'x', value: [2, 3, 5] },
-         { id: 't', value: [2] },
-]
+ [
+          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
+          { year: 2001, dept: { id: 55, value: 'Meuse' } },
+          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
+ ]
 ```
 
 #### Parameters
 
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
+-   `default` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value if no substitution (otherwise value stay unchanged)
+-   `primer` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Data to send to the external pipeline (optional, default `auto`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `persistent` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The internal database will be reused until it is deleted (optional, default `false`)
+-   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### aggregate
+### count
 
-Aggregate by id and count
+Take `Object` and throw special `Object` like `{id, value}` if key(s) was found
+id is the key, value is equal to 1 (if found)
 
 ```json
-[{
-         { id: 'x', value: 2 },
-         { id: 't', value: 2 },
-         { id: 'x', value: 3 },
-         { id: 'x', value: 5 },
-}]
+[
+ {
+      "a": "nancy",
+      "b": "lucy",
+      "c": "geny",
+  },
+  {
+      "a": "lorem",
+      "b": "loret",
+  },
+  {
+      "a": "fred",
+  }
+]
 ```
 
 Script:
@@ -370,42 +243,77 @@ Script:
 ```ini
 [use]
 plugin = analytics
+
+[count]
+path = a
+path = b
+path = c
 
 [aggregate]
-path = id
+[summing]
 ```
 
 Output:
 
 ```json
-[
-         { id: 'x', value: [ 2, 3, 5] },
-         { id: 't', value: [ 2 ]  },
-]
+[{
+   "id": "a",
+   "value": 3
+},
+{
+   "id": "b",
+   "value": 2
+},
+{
+   "id": "c",
+   "value": 1
+}]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (if not found 1 is the default value) (optional, default `value`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### slice
+### distance
 
-Take `Object` and throw the same object only if it is in the section of the
-stream between start and start + size. stream is numbered from 1
+To compare 2 fields with 2 id and compute a distance
+
+-   for arrays, the distance is calculated according to the number of element in common
 
 ```json
 [{
- { id: 2000, value: 1 },
- { id: 2001, value: 2 },
- { id: 2003, value: 3 },
- { id: 2005, value: 4 },
- { id: 2007, value: 5 },
- { id: 2009, value: 6 },
- { id: 2011, value: 7 },
- { id: 2013, value: 8 },
+           {
+              id_of_a: 1,
+              id_of_b: 2,
+              a: ['x', 'y'],
+              b: ['x', 'z'],
+          },
+          {
+              id_of_a: 1,
+              id_of_b: 3,
+              a: ['x', 'y'],
+              b: ['y', 'z'],
+          },
+          {
+              id_of_a: 1,
+              id_of_b: 4,
+              a: ['x', 'y'],
+              b: ['z'],
+          },
+          {
+              id_of_a: 1,
+              id_of_b: 5,
+              a: ['x', 'y'],
+              b: ['x', 'y', 'z'],
+          },
+          {
+              id_of_a: 1,
+              id_of_b: 6,
+              a: ['x', 'y'],
+              b: ['x', 'y'],
+          },
 }]
 ```
 
@@ -415,22 +323,30 @@ Script:
 [use]
 plugin = analytics
 
-[drop]
+[distance]
+id = id_of_a
+id = id_of_b
+value = a
+value = b
 ```
 
 Output:
 
 ```json
 [
-{ "id": 2001, "value": 2 },
-{ "id": 2003, "value": 3 },
+    { id: [ 1, 2 ], value: 0.5 },
+    { id: [ 1, 3 ], value: 0.5 },
+    { id: [ 1, 4 ], value: 0 },
+    { id: [ 1, 5 ], value: 0.8 },
+    { id: [ 1, 6 ], value: 1 }
+  ]
+
 ]
 ```
 
 #### Parameters
 
--   `start` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** start of the slice (optional, default `0`)
--   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of the slice (optional, default `10`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -476,6 +392,161 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### distribute
+
+Take `Object` like { id, value } and throw a serie of number value
+
+```json
+[
+          { id: 2000, value: 1 },
+          { id: 2001, value: 2 },
+          { id: 2003, value: 3 },
+          { id: 2005, value: 4 },
+          { id: 2007, value: 5 },
+          { id: 2009, value: 6 },
+          { id: 2011, value: 7 },
+          { id: 2013, value: 8 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[distribute]
+```
+
+Output:
+
+```json
+[
+      { "id": 2000, "value": 1 },
+     { "id": 2001, "value": 2 },
+     { "id": 2002, "value": 0 },
+     { "id": 2003, "value": 3 },
+     { "id": 2004, "value": 0 },
+     { "id": 2005, "value": 4 },
+     { "id": 2006, "value": 0 },
+     { "id": 2007, "value": 5 },
+     { "id": 2008, "value": 0 },
+     { "id": 2009, "value": 6 },
+     { "id": 2010, "value": 0 },
+     { "id": 2011, "value": 7 },
+     { "id": 2012, "value": 0 },
+     { "id": 2013, "value": 8 }
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
+-   `step` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** step between each value (optional, default `1`)
+-   `start` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** first value to throw (optional, default `minvalueinthestream`)
+-   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of the distribution (optional, default `(maxvalue-minvalue)inthestream`)
+-   `default` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** default value for missing object (optional, default `0`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### drop
+
+Take `Object` and throw the same object only if there the value of the select field is not equals than a value
+
+```json
+[
+  {
+   "departure": "nancy",
+   "arrival": "paris",
+ },
+ {
+   "departure": "nancy",
+   "arrival": "toul",
+ },
+ {
+   "departure": "paris",
+   "arrival": "londre",
+ }
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[drop]
+```
+
+Output:
+
+```json
+[{
+  "departure": "nancy",
+  "arrival": "paris"
+},
+{
+   "departure": "nancy",
+  "arrival": "toul"
+}]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path of the field to compare (optional, default `"value"`)
+-   `if` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** value to compare (optional, default `""`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### expand
+
+Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
+the internal pipeline receive a special object { id, value } id is the item identifier & value is the item path value
+The internal pipeline can expand value with another
+
+```json
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[expand]
+path = dept
+file = ./departement.ini
+```
+
+Output:
+
+```json
+ [
+          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
+          { year: 2001, dept: { id: 55, value: 'Meuse' } },
+          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
+ ]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
+-   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** How many chunk for sending to the external pipeline (optional, default `1`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `cacheName` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Enable cache, with dedicated name
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### exploding
 
 Take `Object` and take values with [value] path (must be an array)
@@ -518,16 +589,14 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### graph
+### files
 
-Take `Object` and throw a new special object (id, value) for each combination of values
+Take `Object` containing filename et throw content by chunk
+
+Note : files must be under the working directory of the Node.js process.
 
 ```json
-[
- { cities: ['berlin', 'nancy', 'toul'] },
- { cities: ['paris', 'nancy', 'toul']},
- { cities: ['paris', 'berlin', 'toul'] },
-}]
+[ fi1e1.csv, file2.csv ]
 ```
 
 Script:
@@ -535,187 +604,23 @@ Script:
 ```ini
 [use]
 plugin = analytics
+plugin = basics
 
-[graph]
-path = cities
+[files]
+[CSVParse]
 ```
 
 Output:
 
 ```json
 [
-  { "id": [ "berlin", "nancy" ], "value": 1 },
-  { "id": [ "berlin", "toul" ], "value": 2 },
-  { "id": [ "nancy", "toul" ], "value": 2 },
-  { "id": [ "nancy", "paris" ], "value": 1 },
-  { "id": [ "paris", "toul" ], "value": 2 },
-  { "id": [ "berlin", "paris" ], "value": 1 }
+(...)
 ]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### upload
-
-save all objects in a temporary file
-For non Buffer chunks, each object is transformed into a
-string of characters in a raw way (no separator)
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[upload]
-cleanupDelay = 5
-```
-
-Output:
-
-```json
- [
-          { id: '/tmp/31234qdE33334dZE', value:3 },
- ]
-```
-
-#### Parameters
-
--   `extension` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file extension (optional, default `bin`)
--   `prefix` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file prefix (optional, default `upload`)
--   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** TTL in seconds, before cleanup the file (EZS_DELAY) (optional, default `3600`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### pair
-
-Take `Object` object getting some fields with json path, and
-throw all pair of value from two fields
-
-```json
-[
- { departure: ['tokyo', 'nancy'], arrival: 'toul' },
- { departure: ['paris', 'nancy'], arrival: 'toul' },
- { departure: ['london', 'berlin'], arrival: 'toul' },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[pair]
-path = departure
-path = arrival
-```
-
-Output:
-
-```json
-[
- { "id": [ "tokyo", "toul" ], "value": 1 },
-{ "id": [ "nancy", "toul" ], "value": 1 },
-{ "id": [ "paris", "toul" ], "value": 1 },
- { "id": [ "nancy", "toul" ], "value": 1 },
- { "id": [ "london", "toul" ], "value": 1 },
- { "id": [ "berlin", "toul" ], "value": 1 }
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### merging
-
-Take special `Object` like `{id, value}` and replace `value` with the merge of `value`s
-
-```json
-[{
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[merging]
-```
-
-Output:
-
-```json
-[
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### summing
-
-Take special `Object` like `{id, value}` and replace `value` with the sum of
-`value`s
-
-```json
-[
- { "id": "A", "value": [1, 1, 1] },
- { "id": "B", "value": [1] },
- { "id": "C", "value": [1, 1, 1, 1] },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[summing]
-```
-
-Output:
-
-```json
-[{
-  "id": "A", "value": 3
-},
-{
-   "id": "B",
-   "value": 1
-},
-{
-   "id": "C",
-  "value": 4
-}]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `location` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path location to find files (optional, default `.`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -765,21 +670,16 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### value
+### graph
 
-Take `Object` object and getting the value field
+Take `Object` and throw a new special object (id, value) for each combination of values
 
 ```json
 [
- { id: 2000, value: 1 },
- { id: 2001, value: 2 },
- { id: 2003, value: 3 },
- { id: 2005, value: 4 },
- { id: 2007, value: 5 },
- { id: 2009, value: 6 },
- { id: 2011, value: 7 },
- { id: 2013, value: 8 },
-]
+ { cities: ['berlin', 'nancy', 'toul'] },
+ { cities: ['paris', 'nancy', 'toul']},
+ { cities: ['paris', 'berlin', 'toul'] },
+}]
 ```
 
 Script:
@@ -788,28 +688,26 @@ Script:
 [use]
 plugin = analytics
 
-[value]
-path = id
+[graph]
+path = cities
 ```
 
 Output:
 
 ```json
 [
-2000,
-2001,
-2003,
-2005,
-2007,
-2009,
-2011,
-2013
+  { "id": [ "berlin", "nancy" ], "value": 1 },
+  { "id": [ "berlin", "toul" ], "value": 2 },
+  { "id": [ "nancy", "toul" ], "value": 2 },
+  { "id": [ "nancy", "paris" ], "value": 1 },
+  { "id": [ "paris", "toul" ], "value": 2 },
+  { "id": [ "berlin", "paris" ], "value": 1 }
 ]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the pah of the value field (optional, default `value`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -862,21 +760,21 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### pluck
+### groupingByEquality
 
-Take `Object` object getting value of fields (with json `path`) and throws an
-object for each value
+Take `Object` like `{ id, value }` and reduce all values with the same `id`
+in a single object
 
 ```json
 [
- { city: 'tokyo', year: 2000, count: 1 },
- { city: 'paris', year: 2001, count: 2 },
- { city: 'london', year: 2003, count: 3 },
- { city: 'nancy', year: 2005, count: 4 },
- { city: 'berlin', year: 2007, count: 5 },
- { city: 'madrid', year: 2009, count: 6 },
- { city: 'stockholm', year: 2011, count: 7 },
- { city: 'bruxelles', year: 2013, count: 8 },
+   { "id": "lorem", "value": 1 },
+   { "id": "Lorem", "value": 1 },
+   { "id": "loren", "value": 1 },
+   { "id": "korem", "value": 1 },
+   { "id": "olrem", "value": 1 },
+   { "id": "toto", "value": 1 },
+   { "id": "titi", "value": 1 },
+   { "id": "lorem", "value": 1 }
 ]
 ```
 
@@ -886,78 +784,29 @@ Script:
 [use]
 plugin = analytics
 
-[pluck]
-path = year
+[groupingByEquality]
+
+[summing]
 ```
 
 Output:
 
 ```json
 [
-{ "id": "year", "value": 2000 },
-{ "id": "year", "value": 2001 },
-{ "id": "year", "value": 2003 },
-{ "id": "year", "value": 2005 },
-{ "id": "year", "value": 2007 },
-{ "id": "year", "value": 2009 },
-{ "id": "year", "value": 2011 },
-{ "id": "year", "value": 2013 }
+  { "id": [ "lorem" ], "value": 2 },
+  { "id": [ "Lorem" ], "value": 1 },
+  { "id": [ "loren" ], "value": 1 },
+  { "id": [ "korem" ], "value": 1 },
+  { "id": [ "olrem" ], "value": 1 },
+  { "id": [ "toto" ], "value": 1 },
+  { "id": [ "titi" ], "value": 1 }
 ]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use form group by (optional, default `id`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### drop
-
-Take `Object` and throw the same object only if there the value of the select field is not equals than a value
-
-```json
-[
-  {
-   "departure": "nancy",
-   "arrival": "paris",
- },
- {
-   "departure": "nancy",
-   "arrival": "toul",
- },
- {
-   "departure": "paris",
-   "arrival": "londre",
- }
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[drop]
-```
-
-Output:
-
-```json
-[{
-  "departure": "nancy",
-  "arrival": "paris"
-},
-{
-   "departure": "nancy",
-  "arrival": "toul"
-}]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path of the field to compare (optional, default `"value"`)
--   `if` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** value to compare (optional, default `""`)
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1055,6 +904,39 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### groupingByModulo
+
+Take `Object` like `{ id, value }` and reduce all `value`s with the same
+modulo computation in a ansingle object
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[groupingByModulo]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### keys
 
 Take `Object` and throws all its keys
@@ -1105,140 +987,6 @@ Output:
 #### Parameters
 
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### groupingByEquality
-
-Take `Object` like `{ id, value }` and reduce all values with the same `id`
-in a single object
-
-```json
-[
-   { "id": "lorem", "value": 1 },
-   { "id": "Lorem", "value": 1 },
-   { "id": "loren", "value": 1 },
-   { "id": "korem", "value": 1 },
-   { "id": "olrem", "value": 1 },
-   { "id": "toto", "value": 1 },
-   { "id": "titi", "value": 1 },
-   { "id": "lorem", "value": 1 }
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[groupingByEquality]
-
-[summing]
-```
-
-Output:
-
-```json
-[
-  { "id": [ "lorem" ], "value": 2 },
-  { "id": [ "Lorem" ], "value": 1 },
-  { "id": [ "loren" ], "value": 1 },
-  { "id": [ "korem" ], "value": 1 },
-  { "id": [ "olrem" ], "value": 1 },
-  { "id": [ "toto" ], "value": 1 },
-  { "id": [ "titi" ], "value": 1 }
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### tune
-
-Take all `Object` and sort them with selected field
-
-```json
-[{
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[tune]
-```
-
-Output:
-
-```json
-[
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for the sort key (optional, default `id`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### multiply
-
-Take `Object` and throw the same object only if there the value of the select field is equals than a value
-Input file:
-
-```json
-[{
-   a: 1,
-   b: 2,
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[multiply]
-path = factor
-value = X
-value = Y
-value = Z
-```
-
-Output:
-
-```json
-[{
-   a: 1,
-   b: 2,
-   factor: X
-},
-{
-   a: 1,
-   b: 2,
-   factor: Y
-},
-{
-   a: 1,
-   b: 2,
-   factor: Z
-},
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path of the field to add (optional, default `"factor"`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** value(s) to set factor field (optional, default `""`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1300,25 +1048,15 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### count
+### maximizing
 
-Take `Object` and throw special `Object` like `{id, value}` if key(s) was found
-id is the key, value is equal to 1 (if found)
+Take special `Object` like `{id, value}` and replace `value` with the max of `value`s
 
 ```json
 [
- {
-      "a": "nancy",
-      "b": "lucy",
-      "c": "geny",
-  },
-  {
-      "a": "lorem",
-      "b": "loret",
-  },
-  {
-      "a": "fred",
-  }
+  { id: 'toul', value: [1, 2, 3] },
+  { id: 'nancy', value: [2, 3, 4] },
+  { id: 'neufchateau', value: [3, 4, 5] },
 ]
 ```
 
@@ -1328,30 +1066,225 @@ Script:
 [use]
 plugin = analytics
 
-[count]
-path = a
-path = b
-path = c
+[maximizing]
+```
 
-[aggregate]
-[summing]
+Output:
+
+```json
+[
+   { "id": "toul", "value": 3 },
+   { "id": "nancy", "value": 4 },
+   { "id": "neufchateau", "value": 5 }
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### merging
+
+Take special `Object` like `{id, value}` and replace `value` with the merge of `value`s
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[merging]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### minimizing
+
+Take special `Object` like `{id, value}` and replace `value` with the min of
+`value`s
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[drop]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### multiply
+
+Take `Object` and throw the same object only if there the value of the select field is equals than a value
+Input file:
+
+```json
+[{
+   a: 1,
+   b: 2,
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[multiply]
+path = factor
+value = X
+value = Y
+value = Z
 ```
 
 Output:
 
 ```json
 [{
-   "id": "a",
-   "value": 3
+   a: 1,
+   b: 2,
+   factor: X
 },
 {
-   "id": "b",
-   "value": 2
+   a: 1,
+   b: 2,
+   factor: Y
 },
 {
-   "id": "c",
-   "value": 1
-}]
+   a: 1,
+   b: 2,
+   factor: Z
+},
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path of the field to add (optional, default `"factor"`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** value(s) to set factor field (optional, default `""`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### output
+
+Format the output with data a meta
+
+#### Parameters
+
+-   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent or not (optional, default `false`)
+-   `meta` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>?** fields to be considered as metadata
+                                      object
+
+#### Examples
+
+Input
+
+
+```javascript
+[
+     { _id: 1, value: 2, total: 2 },
+     { _id: 2, value: 4, total: 2 }
+]
+```
+
+Script
+
+
+```javascript
+.pipe(ezs('output', { meta: 'total' }))
+```
+
+Output
+
+
+```javascript
+{
+    data: [
+        { _id: 1, value: 2 },
+        { _id: 2, value: 4 }
+    ],
+    meta: {
+        total: 2
+    }
+}
+```
+
+Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### pair
+
+Take `Object` object getting some fields with json path, and
+throw all pair of value from two fields
+
+```json
+[
+ { departure: ['tokyo', 'nancy'], arrival: 'toul' },
+ { departure: ['paris', 'nancy'], arrival: 'toul' },
+ { departure: ['london', 'berlin'], arrival: 'toul' },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[pair]
+path = departure
+path = arrival
+```
+
+Output:
+
+```json
+[
+ { "id": [ "tokyo", "toul" ], "value": 1 },
+{ "id": [ "nancy", "toul" ], "value": 1 },
+{ "id": [ "paris", "toul" ], "value": 1 },
+ { "id": [ "nancy", "toul" ], "value": 1 },
+ { "id": [ "london", "toul" ], "value": 1 },
+ { "id": [ "berlin", "toul" ], "value": 1 }
+]
 ```
 
 #### Parameters
@@ -1360,20 +1293,21 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### distribute
+### pluck
 
-Take `Object` like { id, value } and throw a serie of number value
+Take `Object` object getting value of fields (with json `path`) and throws an
+object for each value
 
 ```json
 [
-          { id: 2000, value: 1 },
-          { id: 2001, value: 2 },
-          { id: 2003, value: 3 },
-          { id: 2005, value: 4 },
-          { id: 2007, value: 5 },
-          { id: 2009, value: 6 },
-          { id: 2011, value: 7 },
-          { id: 2013, value: 8 },
+ { city: 'tokyo', year: 2000, count: 1 },
+ { city: 'paris', year: 2001, count: 2 },
+ { city: 'london', year: 2003, count: 3 },
+ { city: 'nancy', year: 2005, count: 4 },
+ { city: 'berlin', year: 2007, count: 5 },
+ { city: 'madrid', year: 2009, count: 6 },
+ { city: 'stockholm', year: 2011, count: 7 },
+ { city: 'bruxelles', year: 2013, count: 8 },
 ]
 ```
 
@@ -1383,55 +1317,41 @@ Script:
 [use]
 plugin = analytics
 
-[distribute]
+[pluck]
+path = year
 ```
 
 Output:
 
 ```json
 [
-      { "id": 2000, "value": 1 },
-     { "id": 2001, "value": 2 },
-     { "id": 2002, "value": 0 },
-     { "id": 2003, "value": 3 },
-     { "id": 2004, "value": 0 },
-     { "id": 2005, "value": 4 },
-     { "id": 2006, "value": 0 },
-     { "id": 2007, "value": 5 },
-     { "id": 2008, "value": 0 },
-     { "id": 2009, "value": 6 },
-     { "id": 2010, "value": 0 },
-     { "id": 2011, "value": 7 },
-     { "id": 2012, "value": 0 },
-     { "id": 2013, "value": 8 }
+{ "id": "year", "value": 2000 },
+{ "id": "year", "value": 2001 },
+{ "id": "year", "value": 2003 },
+{ "id": "year", "value": 2005 },
+{ "id": "year", "value": 2007 },
+{ "id": "year", "value": 2009 },
+{ "id": "year", "value": 2011 },
+{ "id": "year", "value": 2013 }
 ]
 ```
 
 #### Parameters
 
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
--   `step` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** step between each value (optional, default `1`)
--   `start` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** first value to throw (optional, default `minvalueinthestream`)
--   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of the distribution (optional, default `(maxvalue-minvalue)inthestream`)
--   `default` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** default value for missing object (optional, default `0`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use form group by (optional, default `id`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### sort
+### reducing
 
-Take all `Object` and sort them with dedicated key
+Take `Object` group value of `{ id, value }` objectpath
 
 ```json
 [{
- { id: 2000, value: 1 },
- { id: 2001, value: 2 },
- { id: 2003, value: 3 },
- { id: 2005, value: 4 },
- { id: 2007, value: 5 },
- { id: 2009, value: 6 },
- { id: 2011, value: 7 },
- { id: 2013, value: 8 },
+         { id: 'x', value: 2 },
+         { id: 't', value: 2 },
+         { id: 'x', value: 3 },
+         { id: 'x', value: 5 },
 }]
 ```
 
@@ -1441,199 +1361,22 @@ Script:
 [use]
 plugin = analytics
 
-[sort]
-path = value
-reverse = true
+[reducing]
 ```
 
 Output:
 
 ```json
 [
-{ "id": 2013, "value": 8 },
-{ "id": 2011, "value": 7 },
-{ "id": 2009, "value": 6 },
-{ "id": 2007, "value": 5 },
-{ "id": 2005, "value": 4 },
-{ "id": 2003, "value": 3 },
-{ "id": 2001, "value": 2 },
-{ "id": 2000, "value": 1 }
+         { id: 'x', value: [2, 3, 5] },
+         { id: 't', value: [2] },
 ]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `reverse` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** reverser order (optional, default `false`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### combine
-
-Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
-the internal pipeline must produce a stream of special object (id, value)
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[combine]
-path = dept
-file = ./departement.ini
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
-          { year: 2001, dept: { id: 55, value: 'Meuse' } },
-          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
- ]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
--   `default` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value if no substitution (otherwise value stay unchanged)
--   `primer` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Data to send to the external pipeline (optional, default `auto`)
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `persistent` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The internal database will be reused until it is deleted (optional, default `false`)
--   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### distance
-
-To compare 2 fields with 2 id and compute a distance
-
--   for arrays, the distance is calculated according to the number of element in common
-
-```json
-[{
-           {
-              id_of_a: 1,
-              id_of_b: 2,
-              a: ['x', 'y'],
-              b: ['x', 'z'],
-          },
-          {
-              id_of_a: 1,
-              id_of_b: 3,
-              a: ['x', 'y'],
-              b: ['y', 'z'],
-          },
-          {
-              id_of_a: 1,
-              id_of_b: 4,
-              a: ['x', 'y'],
-              b: ['z'],
-          },
-          {
-              id_of_a: 1,
-              id_of_b: 5,
-              a: ['x', 'y'],
-              b: ['x', 'y', 'z'],
-          },
-          {
-              id_of_a: 1,
-              id_of_b: 6,
-              a: ['x', 'y'],
-              b: ['x', 'y'],
-          },
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[distance]
-id = id_of_a
-id = id_of_b
-value = a
-value = b
-```
-
-Output:
-
-```json
-[
-    { id: [ 1, 2 ], value: 0.5 },
-    { id: [ 1, 3 ], value: 0.5 },
-    { id: [ 1, 4 ], value: 0 },
-    { id: [ 1, 5 ], value: 0.8 },
-    { id: [ 1, 6 ], value: 1 }
-  ]
-
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### expand
-
-Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
-the internal pipeline receive a special object { id, value } id is the item identifier & value is the item path value
-The internal pipeline can expand value with another
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[expand]
-path = dept
-file = ./departement.ini
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
-          { year: 2001, dept: { id: 55, value: 'Meuse' } },
-          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
- ]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
--   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** How many chunk for sending to the external pipeline (optional, default `1`)
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `cacheName` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Enable cache, with dedicated name
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1716,6 +1459,99 @@ Output:
 
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `value`)
 -   `aggregate` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** aggregate all values for all paths (or not) (optional, default `true`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### slice
+
+Take `Object` and throw the same object only if it is in the section of the
+stream between start and start + size. stream is numbered from 1
+
+```json
+[{
+ { id: 2000, value: 1 },
+ { id: 2001, value: 2 },
+ { id: 2003, value: 3 },
+ { id: 2005, value: 4 },
+ { id: 2007, value: 5 },
+ { id: 2009, value: 6 },
+ { id: 2011, value: 7 },
+ { id: 2013, value: 8 },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[drop]
+```
+
+Output:
+
+```json
+[
+{ "id": 2001, "value": 2 },
+{ "id": 2003, "value": 3 },
+]
+```
+
+#### Parameters
+
+-   `start` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** start of the slice (optional, default `0`)
+-   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of the slice (optional, default `10`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### sort
+
+Take all `Object` and sort them with dedicated key
+
+```json
+[{
+ { id: 2000, value: 1 },
+ { id: 2001, value: 2 },
+ { id: 2003, value: 3 },
+ { id: 2005, value: 4 },
+ { id: 2007, value: 5 },
+ { id: 2009, value: 6 },
+ { id: 2011, value: 7 },
+ { id: 2013, value: 8 },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[sort]
+path = value
+reverse = true
+```
+
+Output:
+
+```json
+[
+{ "id": 2013, "value": 8 },
+{ "id": 2011, "value": 7 },
+{ "id": 2009, "value": 6 },
+{ "id": 2007, "value": 5 },
+{ "id": 2005, "value": 4 },
+{ "id": 2003, "value": 3 },
+{ "id": 2001, "value": 2 },
+{ "id": 2000, "value": 1 }
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `reverse` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** reverser order (optional, default `false`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1827,5 +1663,169 @@ Output
 }]
 ```
 ````
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### summing
+
+Take special `Object` like `{id, value}` and replace `value` with the sum of
+`value`s
+
+```json
+[
+ { "id": "A", "value": [1, 1, 1] },
+ { "id": "B", "value": [1] },
+ { "id": "C", "value": [1, 1, 1, 1] },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[summing]
+```
+
+Output:
+
+```json
+[{
+  "id": "A", "value": 3
+},
+{
+   "id": "B",
+   "value": 1
+},
+{
+   "id": "C",
+  "value": 4
+}]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### tune
+
+Take all `Object` and sort them with selected field
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[tune]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for the sort key (optional, default `id`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### upload
+
+save all objects in a temporary file
+For non Buffer chunks, each object is transformed into a
+string of characters in a raw way (no separator)
+
+```json
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[upload]
+cleanupDelay = 5
+```
+
+Output:
+
+```json
+ [
+          { id: '/tmp/31234qdE33334dZE', value:3 },
+ ]
+```
+
+#### Parameters
+
+-   `extension` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file extension (optional, default `bin`)
+-   `prefix` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file prefix (optional, default `upload`)
+-   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** TTL in seconds, before cleanup the file (EZS_DELAY) (optional, default `3600`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### value
+
+Take `Object` object and getting the value field
+
+```json
+[
+ { id: 2000, value: 1 },
+ { id: 2001, value: 2 },
+ { id: 2003, value: 3 },
+ { id: 2005, value: 4 },
+ { id: 2007, value: 5 },
+ { id: 2009, value: 6 },
+ { id: 2011, value: 7 },
+ { id: 2013, value: 8 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[value]
+path = id
+```
+
+Output:
+
+```json
+[
+2000,
+2001,
+2003,
+2005,
+2007,
+2009,
+2011,
+2013
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the pah of the value field (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/docs/plugin-conditor.md
+++ b/docs/plugin-conditor.md
@@ -52,9 +52,57 @@ Sachant qu'on appauvrit (casse, accents, tiret, apostrophe) tous les champs.
 
 #### Table of Contents
 
+-   [affAlign](#affalign)
 -   [compareRnsr](#comparernsr)
 -   [conditorScroll](#conditorscroll)
--   [affAlign](#affalign)
+
+### affAlign
+
+Find the RNSR identifiers in the authors affiliation addresses.
+
+Input file:
+
+```json
+[{
+     "xPublicationDate": ["2012-01-01", "2012-01-01"],
+     "authors": [{
+         "affiliations": [{
+             "address": "GDR 2989 Université Versailles Saint-Quentin-en-Yvelines, 63009"
+         }]
+     }]
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = basics
+plugin = conditor
+
+[JSONParse]
+[affAlign]
+[JSONString]
+indent = true
+```
+
+Output:
+
+```json
+[{
+     "xPublicationDate": ["2012-01-01", "2012-01-01"],
+     "authors": [{
+         "affiliations": [{
+             "address": "GDR 2989 Université Versailles Saint-Quentin-en-Yvelines, 63009",
+             "conditorRnsr": ["200619958X"]
+         }]
+     }]
+}]
+```
+
+#### Parameters
+
+-   `year` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Year of the RNSR to use instead of the last one
 
 ### compareRnsr
 
@@ -140,51 +188,3 @@ Output
 ```
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
-
-### affAlign
-
-Find the RNSR identifiers in the authors affiliation addresses.
-
-Input file:
-
-```json
-[{
-     "xPublicationDate": ["2012-01-01", "2012-01-01"],
-     "authors": [{
-         "affiliations": [{
-             "address": "GDR 2989 Université Versailles Saint-Quentin-en-Yvelines, 63009"
-         }]
-     }]
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = basics
-plugin = conditor
-
-[JSONParse]
-[affAlign]
-[JSONString]
-indent = true
-```
-
-Output:
-
-```json
-[{
-     "xPublicationDate": ["2012-01-01", "2012-01-01"],
-     "authors": [{
-         "affiliations": [{
-             "address": "GDR 2989 Université Versailles Saint-Quentin-en-Yvelines, 63009",
-             "conditorRnsr": ["200619958X"]
-         }]
-     }]
-}]
-```
-
-#### Parameters
-
--   `year` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Year of the RNSR to use instead of the last one

--- a/docs/plugin-core.md
+++ b/docs/plugin-core.md
@@ -14,213 +14,38 @@ npm install @ezs/core
 
 #### Table of Contents
 
--   [pack](#pack)
--   [unpack](#unpack)
--   [tracer](#tracer)
--   [env](#env)
--   [spawn](#spawn)
+-   [assign](#assign)
+-   [concat](#concat)
 -   [debug](#debug)
 -   [delegate](#delegate)
 -   [dispatch](#dispatch)
--   [metrics](#metrics)
--   [swing](#swing)
--   [parallel](#parallel)
--   [time](#time)
--   [transit](#transit)
--   [concat](#concat)
--   [ungroup](#ungroup)
--   [group](#group)
--   [shift](#shift)
+-   [dump](#dump)
+-   [env](#env)
 -   [exchange](#exchange)
 -   [extract](#extract)
--   [keep](#keep)
+-   [group](#group)
 -   [ignore](#ignore)
--   [dump](#dump)
+-   [keep](#keep)
+-   [metrics](#metrics)
+-   [pack](#pack)
+-   [parallel](#parallel)
 -   [remove](#remove)
--   [truncate](#truncate)
--   [shuffle](#shuffle)
--   [validate](#validate)
 -   [replace](#replace)
--   [assign](#assign)
-
-### pack
-
-Take all `Object`, throw encoded `String`
-
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### unpack
-
-Take `String` and throw `Object` builded by JSON.parse on each line
-
-Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### tracer
-
-Take `Object`, print a character and throw the same object.
-Useful to see the progress in the stream.
-
-#### Parameters
-
--   `print` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at each object (optional, default `.`)
--   `last` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at last call (optional, default `.`)
--   `first` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at first call (optional, default `.`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### env
-
-Take `Object` and send the same object but in the meantime,
-it is possible to  add new environment field with the first
-Object of the feed
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the new field
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value of the new field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### spawn
-
-Take `Object` and delegate processing to an external pipeline, throw each chunk from the result
-Note : works like [delegate], but each chunk use its own external pipeline
-
-#### Parameters
-
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### debug
-
-Take `Object` , print it and throw the same object
-
-#### Parameters
-
--   `level` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** console level : log or error (optional, default `log`)
--   `text` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** text before the dump (optional, default `valueOf`)
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to print
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### delegate
-
-Takes an `Object` delegate processing to an external pipeline
-Note : works like [spawn], but each chunk share the same external pipeline
-
-#### Parameters
-
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### dispatch
-
-Takes an `Object` dispatch processing to an external pipeline on one or more servers
-
-#### Parameters
-
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### metrics
-
-Take `Object` and throw the same `Object`
-But in print some Prometheus metrics
-
-#### Parameters
-
--   `stage` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Stage name (optional, default `default`)
--   `bucket` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Bucket name (script name) (optional, default `unknow`)
--   `frequency` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** number of chunk between two metrics computation (optional, default `10`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### swing
-
-Takes an `Object` delegate processing to an external pipeline
-under specifics conditions
-Note : works like [spawn], but each chunk share the same external pipeline
-
-#### Parameters
-
--   `test` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** if test is true
--   `reverse` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reverse the test (optional, default `false`)
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### parallel
-
-Takes an `Object` delegate processing to X internal pipelines
-
-#### Parameters
-
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### time
-
-Measure the execution time of a script, on each chunk on input.
-
-#### Parameters
-
--   `script` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
-
-#### Examples
-
-Input
-
-
-```javascript
-[1]
-```
-
-Program
-
-
-```javascript
-const script = `
-[transit]
-`;
-from([1])
-    .pipe(ezs('time', { script }))
-```
-
-Output
-
-
-```javascript
-[{
-  data: 1,
-  time: 15 // milliseconds
-}]
-```
-
-Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### transit
-
-Take `Object` and throw the same object
+-   [shift](#shift)
+-   [shuffle](#shuffle)
+-   [spawn](#spawn)
+-   [swing](#swing)
+-   [time](#time)
+-   [tracer](#tracer)
+-   [transit](#transit)
+-   [truncate](#truncate)
+-   [ungroup](#ungroup)
+-   [unpack](#unpack)
+-   [validate](#validate)
+
+### assign
+
+Take `Object` and add new field
 Input file:
 
 ```json
@@ -229,13 +54,24 @@ Input file:
 },
 {
    a: 2,
+},
+{
+   a: 3,
+},
+{
+   a: 4,
+},
+{
+   a: 5,
 }]
 ```
 
 Script:
 
 ```ini
-[transit]
+[assign]
+path = b.c
+value = 'X'
 ```
 
 Output:
@@ -243,11 +79,30 @@ Output:
 ```json
 [{
    a: 1,
+   b: { c: "X" },
 },
 {
    a: 2,
+   b: { c: "X" },
+},
+{
+   a: 3,
+   b: { c: "X" },
+},
+{
+   a: 4,
+   b: { c: "X" },
+},
+{
+   a: 5,
+   b: { c: "X" },
 }]
 ```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the new field
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value of the new field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -288,120 +143,103 @@ Output:
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
-### ungroup
+### debug
 
--   **See: group
-    **
+Take `Object` , print it and throw the same object
 
-Take all `chunk`s, and throw one item for every chunk
+#### Parameters
+
+-   `level` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** console level : log or error (optional, default `log`)
+-   `text` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** text before the dump (optional, default `valueOf`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to print
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### delegate
+
+Takes an `Object` delegate processing to an external pipeline
+Note : works like [spawn], but each chunk share the same external pipeline
+
+#### Parameters
+
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### dispatch
+
+Takes an `Object` dispatch processing to an external pipeline on one or more servers
+
+#### Parameters
+
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### dump
+
+Take all `Object` and generete a JSON array
 
 ```json
 [
-     [ 'a', 'b', 'c' ],
-     [ 'd', 'e', 'f' ],
-     [ 'g', 'h' ],
+    { a: 1 },
+    { a: 2 },
+    { a: 3 },
+    { a: 4 },
+    { a: 5 }
 ]
 ```
 
 Script:
 
 ```ini
-[ungroup]
+[dump]
+indent = true
 ```
 
 Output:
 
 ```json
-[
-     'a',
-     'b',
-     'c',
-     'd',
-     'e',
-     'f',
-     'g',
-     'h',
-]
-```
-
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### group
-
-Take all `chunk`s, and throw one array of chunks
-
-```json
-[
-     'a',
-     'b',
-     'c',
-     'd',
-     'e',
-     'f',
-     'g',
-     'h',
-]
-```
-
-Script:
-
-```ini
-[group]
-length = 3
-```
-
-Output:
-
-```json
-[
-     [ 'a', 'b', 'c' ],
-     [ 'd', 'e', 'f' ],
-     [ 'g', 'h' ],
+ [{
+    "a": 1
+   },
+   {
+    "a": 2
+   },
+   {
+    "a": 3
+   },
+   {
+    "a": 4
+   },
+   {
+    "a": 5
+   }
 ]
 ```
 
 #### Parameters
 
--   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Size of each partition
+-   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent JSON (optional, default `false`)
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
-### shift
+### env
 
-Return the first `Object` and close the feed
-Input file:
+Take `Object` and send the same object but in the meantime,
+it is possible to  add new environment field with the first
+Object of the feed
 
-```json
-[{
-   a: 1,
-},
-{
-   a: 2,
-},
-{
-   a: 3,
-},
-{
-   a: 4,
-},
-{
-   a: 5,
-}]
-```
+#### Parameters
 
-Script:
-
-```ini
-[shift]
-```
-
-Output:
-
-```json
-[{
-   a: 1,
-}]
-```
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the new field
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value of the new field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -492,50 +330,45 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### keep
+### group
 
-Take `Object` and throw the same object but keep only specific fields
-Input file:
+Take all `chunk`s, and throw one array of chunks
 
 ```json
-[{
-   a: 'abcdefg',
-   b: '1234567',
-   c: 'XXXXXXX',
-},
-{
-   a: 'abcdefg',
-   b: '1234567',
-   c: 'XXXXXXX',
-}]
+[
+     'a',
+     'b',
+     'c',
+     'd',
+     'e',
+     'f',
+     'g',
+     'h',
+]
 ```
 
 Script:
 
 ```ini
-[keep]
-path = a
-path = b
+[group]
+length = 3
 ```
 
 Output:
 
 ```json
-[{
-   a: 'abcdefg',
-   b: '1234567',
-},
-{
-   a: 'abcdefg',
-   b: '1234567',
-}]
+[
+     [ 'a', 'b', 'c' ],
+     [ 'd', 'e', 'f' ],
+     [ 'g', 'h' ],
+]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to keep
+-   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Size of each partition
 
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ### ignore
 
@@ -584,53 +417,82 @@ Output:
 
 Returns **any** 
 
-### dump
+### keep
 
-Take all `Object` and generete a JSON array
+Take `Object` and throw the same object but keep only specific fields
+Input file:
 
 ```json
-[
-    { a: 1 },
-    { a: 2 },
-    { a: 3 },
-    { a: 4 },
-    { a: 5 }
-]
+[{
+   a: 'abcdefg',
+   b: '1234567',
+   c: 'XXXXXXX',
+},
+{
+   a: 'abcdefg',
+   b: '1234567',
+   c: 'XXXXXXX',
+}]
 ```
 
 Script:
 
 ```ini
-[dump]
-indent = true
+[keep]
+path = a
+path = b
 ```
 
 Output:
 
 ```json
- [{
-    "a": 1
-   },
-   {
-    "a": 2
-   },
-   {
-    "a": 3
-   },
-   {
-    "a": 4
-   },
-   {
-    "a": 5
-   }
-]
+[{
+   a: 'abcdefg',
+   b: '1234567',
+},
+{
+   a: 'abcdefg',
+   b: '1234567',
+}]
 ```
 
 #### Parameters
 
--   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent JSON (optional, default `false`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to keep
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### metrics
+
+Take `Object` and throw the same `Object`
+But in print some Prometheus metrics
+
+#### Parameters
+
+-   `stage` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Stage name (optional, default `default`)
+-   `bucket` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Bucket name (script name) (optional, default `unknow`)
+-   `frequency` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** number of chunk between two metrics computation (optional, default `10`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### pack
+
+Take all `Object`, throw encoded `String`
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### parallel
+
+Takes an `Object` delegate processing to X internal pipelines
+
+#### Parameters
+
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### remove
 
@@ -679,156 +541,6 @@ Output:
 
 -   `test` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** if test is true
 -   `reverse` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reverse the test (optional, default `false`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### truncate
-
-Takes all the chunks, and closes the feed when the total length is equal to the parameter
-Input file:
-
-```json
-[{
-   a: 1,
-},
-{
-   a: 2,
-},
-{
-   a: 3,
-},
-{
-   a: 4,
-},
-{
-   a: 5,
-}]
-```
-
-Script:
-
-```ini
-[truncate]
-length = 3
-```
-
-Output:
-
-```json
-[{
-   a: 1,
-},
-{
-   a: 2,
-},
-{
-   a: 3,
-}]
-```
-
-#### Parameters
-
--   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Length of the feed
-
-Returns **any** 
-
-### shuffle
-
-Take `Object`, shuffle data of the whole object or only some fields specified by path
-Input file:
-
-```json
-[{
-   a: 'abcdefg',
-   b: '1234567',
-},
-{
-   a: 'abcdefg',
-   b: '1234567',
-}]
-```
-
-Script:
-
-```ini
-[shuffle]
-path = a
-```
-
-Output:
-
-```json
-[{
-   a: 'cadbefg',
-   b: '1234567',
-},
-{
-   a: 'dcaegbf',
-   b: '1234567',
-}]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to shuffle
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### validate
-
--   **See: laravel validator rules
-    **
--   **See: <https://github.com/skaterdav85/validatorjs#readme>
-    **
-
-From a `Object`, throw the same object if all rules pass
-
-Input file:
-
-```json
-[{
-   a: 1,
-   b: 'titi',
-},
-{
-   a: 2,
-   b: 'toto',
-},
-{
-   a: false,
-},
-]
-```
-
-Script:
-
-```ini
-[validate]
-path = a
-rule = required|number
-
-path = a
-rule = required|string
-```
-
-Output:
-
-```json
-[{
-   a: 1,
-   b: 'titi',
-},
-{
-   a: 2,
-   b: 'toto',
-},
-}]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the field
--   `rule` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** rule to validate the field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -890,9 +602,9 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### assign
+### shift
 
-Take `Object` and add new field
+Return the first `Object` and close the feed
 Input file:
 
 ```json
@@ -916,9 +628,7 @@ Input file:
 Script:
 
 ```ini
-[assign]
-path = b.c
-value = 'X'
+[shift]
 ```
 
 Output:
@@ -926,29 +636,319 @@ Output:
 ```json
 [{
    a: 1,
-   b: { c: "X" },
+}]
+```
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### shuffle
+
+Take `Object`, shuffle data of the whole object or only some fields specified by path
+Input file:
+
+```json
+[{
+   a: 'abcdefg',
+   b: '1234567',
 },
 {
-   a: 2,
-   b: { c: "X" },
+   a: 'abcdefg',
+   b: '1234567',
+}]
+```
+
+Script:
+
+```ini
+[shuffle]
+path = a
+```
+
+Output:
+
+```json
+[{
+   a: 'cadbefg',
+   b: '1234567',
 },
 {
-   a: 3,
-   b: { c: "X" },
-},
-{
-   a: 4,
-   b: { c: "X" },
-},
-{
-   a: 5,
-   b: { c: "X" },
+   a: 'dcaegbf',
+   b: '1234567',
 }]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the new field
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value of the new field
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to shuffle
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### spawn
+
+Take `Object` and delegate processing to an external pipeline, throw each chunk from the result
+Note : works like [delegate], but each chunk use its own external pipeline
+
+#### Parameters
+
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### swing
+
+Takes an `Object` delegate processing to an external pipeline
+under specifics conditions
+Note : works like [spawn], but each chunk share the same external pipeline
+
+#### Parameters
+
+-   `test` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** if test is true
+-   `reverse` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reverse the test (optional, default `false`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### time
+
+Measure the execution time of a script, on each chunk on input.
+
+#### Parameters
+
+-   `script` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+
+#### Examples
+
+Input
+
+
+```javascript
+[1]
+```
+
+Program
+
+
+```javascript
+const script = `
+[transit]
+`;
+from([1])
+    .pipe(ezs('time', { script }))
+```
+
+Output
+
+
+```javascript
+[{
+  data: 1,
+  time: 15 // milliseconds
+}]
+```
+
+Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### tracer
+
+Take `Object`, print a character and throw the same object.
+Useful to see the progress in the stream.
+
+#### Parameters
+
+-   `print` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at each object (optional, default `.`)
+-   `last` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at last call (optional, default `.`)
+-   `first` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at first call (optional, default `.`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### transit
+
+Take `Object` and throw the same object
+Input file:
+
+```json
+[{
+   a: 1,
+},
+{
+   a: 2,
+}]
+```
+
+Script:
+
+```ini
+[transit]
+```
+
+Output:
+
+```json
+[{
+   a: 1,
+},
+{
+   a: 2,
+}]
+```
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### truncate
+
+Takes all the chunks, and closes the feed when the total length is equal to the parameter
+Input file:
+
+```json
+[{
+   a: 1,
+},
+{
+   a: 2,
+},
+{
+   a: 3,
+},
+{
+   a: 4,
+},
+{
+   a: 5,
+}]
+```
+
+Script:
+
+```ini
+[truncate]
+length = 3
+```
+
+Output:
+
+```json
+[{
+   a: 1,
+},
+{
+   a: 2,
+},
+{
+   a: 3,
+}]
+```
+
+#### Parameters
+
+-   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Length of the feed
+
+Returns **any** 
+
+### ungroup
+
+-   **See: group
+    **
+
+Take all `chunk`s, and throw one item for every chunk
+
+```json
+[
+     [ 'a', 'b', 'c' ],
+     [ 'd', 'e', 'f' ],
+     [ 'g', 'h' ],
+]
+```
+
+Script:
+
+```ini
+[ungroup]
+```
+
+Output:
+
+```json
+[
+     'a',
+     'b',
+     'c',
+     'd',
+     'e',
+     'f',
+     'g',
+     'h',
+]
+```
+
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### unpack
+
+Take `String` and throw `Object` builded by JSON.parse on each line
+
+Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### validate
+
+-   **See: laravel validator rules
+    **
+-   **See: <https://github.com/skaterdav85/validatorjs#readme>
+    **
+
+From a `Object`, throw the same object if all rules pass
+
+Input file:
+
+```json
+[{
+   a: 1,
+   b: 'titi',
+},
+{
+   a: 2,
+   b: 'toto',
+},
+{
+   a: false,
+},
+]
+```
+
+Script:
+
+```ini
+[validate]
+path = a
+rule = required|number
+
+path = a
+rule = required|string
+```
+
+Output:
+
+```json
+[{
+   a: 1,
+   b: 'titi',
+},
+{
+   a: 2,
+   b: 'toto',
+},
+}]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the field
+-   `rule` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** rule to validate the field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/docs/plugin-istex.md
+++ b/docs/plugin-istex.md
@@ -14,8 +14,8 @@ npm install @ezs/istex
 
 #### Table of Contents
 
--   [ISTEXUnzip](#istexunzip)
 -   [ISTEXFiles](#istexfiles)
+-   [ISTEXUnzip](#istexunzip)
 -   [ISTEXFilesContent](#istexfilescontent)
 -   [ISTEXResult](#istexresult)
 -   [ISTEXFacet](#istexfacet)
@@ -27,15 +27,6 @@ npm install @ezs/istex
 -   [ISTEXTriplify](#istextriplify)
 -   [ISTEXUniq](#istexuniq)
 -   [ISTEX](#istex)
-
-### ISTEXUnzip
-
-Take the content of a zip file, extract JSON files, and yield JSON objects.
-
-The zip file comes from dl.istex.fr, and the `manifest.json` is not
-extracted.
-
-Returns **any** Array<Object>
 
 ### ISTEXFiles
 
@@ -52,6 +43,15 @@ Take an Object with ISTEX `id` and generate an object for each file
 -   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
+
+### ISTEXUnzip
+
+Take the content of a zip file, extract JSON files, and yield JSON objects.
+
+The zip file comes from dl.istex.fr, and the `manifest.json` is not
+extracted.
+
+Returns **any** Array<Object>
 
 ### ISTEXFilesContent
 

--- a/docs/plugin-istex.md
+++ b/docs/plugin-istex.md
@@ -14,75 +14,43 @@ npm install @ezs/istex
 
 #### Table of Contents
 
--   [ISTEXFiles](#istexfiles)
--   [ISTEXUnzip](#istexunzip)
--   [ISTEXFilesContent](#istexfilescontent)
--   [ISTEXResult](#istexresult)
+-   [ISTEX](#istex)
 -   [ISTEXFacet](#istexfacet)
--   [ISTEXFilesWrap](#istexfileswrap)
--   [ISTEXScroll](#istexscroll)
 -   [ISTEXFetch](#istexfetch)
+-   [ISTEXFiles](#istexfiles)
+-   [ISTEXFilesContent](#istexfilescontent)
+-   [ISTEXFilesWrap](#istexfileswrap)
 -   [ISTEXParseDotCorpus](#istexparsedotcorpus)
+-   [ISTEXResult](#istexresult)
 -   [ISTEXSave](#istexsave)
+-   [ISTEXScroll](#istexscroll)
 -   [ISTEXTriplify](#istextriplify)
 -   [ISTEXUniq](#istexuniq)
--   [ISTEX](#istex)
+-   [ISTEXUnzip](#istexunzip)
 
-### ISTEXFiles
+### ISTEX
 
--   **See: ISTEXScroll
-    **
-
-Take an Object with ISTEX `id` and generate an object for each file
+Take an array and returns matching documents for every value of the array
 
 #### Parameters
 
--   `fulltext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** typology of the document to save (optional, default `pdf`)
--   `metadata` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** format of the files to save (optional, default `json`)
--   `enrichment` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** enrichment of the document to save
--   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
+-   `query` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** ISTEX query (or queries) (optional, default `data.query||[]`)
+-   `id` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** ISTEX id (or ids) (optional, default `data.id||[]`)
+-   `maxPage` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** maximum number of pages to get
+-   `size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of each page of results
+-   `duration` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** maximum duration between two requests (ex: "30s")
+-   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** fields to output
 
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
+#### Examples
 
-### ISTEXUnzip
-
-Take the content of a zip file, extract JSON files, and yield JSON objects.
-
-The zip file comes from dl.istex.fr, and the `manifest.json` is not
-extracted.
-
-Returns **any** Array<Object>
-
-### ISTEXFilesContent
-
--   **See: ISTEXFiles
-    **
-
-Take an Object with ISTEX `source` and check the document's file.
-Warning: to access fulltext, you have to give a `token` parameter.
-ISTEXFetch produces the stream you need to save the file.
-
-#### Parameters
-
--   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
--   `token` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** authentication token (see [documentation](https://doc.istex.fr/api/access/fede.html#acc%C3%A8s-programmatique-via-un-token-didentification))
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### ISTEXResult
-
--   **See: ISTEXScroll
-    **
-
-Take `Object` containing results of ISTEX API, and returns `hits` value
-(documents).
-
-This should be placed after ISTEXScroll.
-
-#### Parameters
-
--   `source` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `data`)
--   `target` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `feed`)
+```javascript
+.pipe(ezs('ISTEX', {
+  query: 'this is a test',
+  size: 3,
+  maxPage: 1,
+  sid: 'test'
+}))
+```
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
 
@@ -102,42 +70,6 @@ aggregations from the ISTEX API.
 ```javascript
 from([{ query: 'ezs', facet: 'corpusName' }])
   .pipe(ezs('ISTEXFacet', { sid: 'test', }))
-```
-
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
-
-### ISTEXFilesWrap
-
--   **See: ISTEXFiles
-    **
-
-Take and Object with ISTEX `stream` and wrap into a single zip
-
-Returns **[Buffer](https://nodejs.org/api/buffer.html)** 
-
-### ISTEXScroll
-
-Take an object containing a query string field and output records from the
-ISTEX API. Every output record is merged with the input object.
-
-#### Parameters
-
--   `query` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** ISTEX query (optional, default `input`)
--   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
--   `maxPage` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Maximum number of pages to get
--   `size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of each page of results (optional, default `2000`)
--   `duration` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** maximum duration between two requests (optional, default `"5m"`)
--   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** fields to get (optional, default `["doi"]`)
-
-#### Examples
-
-```javascript
-from([{ query: 'this is a test' }])
-  .pipe(ezs('ISTEXScroll', {
-      maxPage: 2,
-      size: 1,
-      sid: 'test',
-  }))
 ```
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
@@ -175,6 +107,47 @@ will produce two JSON records.
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
 
+### ISTEXFiles
+
+-   **See: ISTEXScroll
+    **
+
+Take an Object with ISTEX `id` and generate an object for each file
+
+#### Parameters
+
+-   `fulltext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** typology of the document to save (optional, default `pdf`)
+-   `metadata` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** format of the files to save (optional, default `json`)
+-   `enrichment` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** enrichment of the document to save
+-   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
+
+### ISTEXFilesContent
+
+-   **See: ISTEXFiles
+    **
+
+Take an Object with ISTEX `source` and check the document's file.
+Warning: to access fulltext, you have to give a `token` parameter.
+ISTEXFetch produces the stream you need to save the file.
+
+#### Parameters
+
+-   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
+-   `token` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** authentication token (see [documentation](https://doc.istex.fr/api/access/fede.html#acc%C3%A8s-programmatique-via-un-token-didentification))
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### ISTEXFilesWrap
+
+-   **See: ISTEXFiles
+    **
+
+Take and Object with ISTEX `stream` and wrap into a single zip
+
+Returns **[Buffer](https://nodejs.org/api/buffer.html)** 
+
 ### ISTEXParseDotCorpus
 
 Parse a `.corpus` file content, and execute the action contained in the
@@ -208,6 +181,23 @@ id 2FF3F5B1477986B9C617BB75CA3333DBEE99EB05
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### ISTEXResult
+
+-   **See: ISTEXScroll
+    **
+
+Take `Object` containing results of ISTEX API, and returns `hits` value
+(documents).
+
+This should be placed after ISTEXScroll.
+
+#### Parameters
+
+-   `source` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `data`)
+-   `target` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `feed`)
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
+
 ### ISTEXSave
 
 -   **See: ISTEXFetch
@@ -226,6 +216,33 @@ ISTEXFetch produces the stream you need to save the file.
 -   `token` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** authentication token (see [documentation](https://doc.istex.fr/api/access/fede.html#acc%C3%A8s-programmatique-via-un-token-didentification))
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
+
+### ISTEXScroll
+
+Take an object containing a query string field and output records from the
+ISTEX API. Every output record is merged with the input object.
+
+#### Parameters
+
+-   `query` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** ISTEX query (optional, default `input`)
+-   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
+-   `maxPage` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Maximum number of pages to get
+-   `size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of each page of results (optional, default `2000`)
+-   `duration` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** maximum duration between two requests (optional, default `"5m"`)
+-   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** fields to get (optional, default `["doi"]`)
+
+#### Examples
+
+```javascript
+from([{ query: 'this is a test' }])
+  .pipe(ezs('ISTEXScroll', {
+      maxPage: 2,
+      size: 1,
+      sid: 'test',
+  }))
+```
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
 
 ### ISTEXTriplify
 
@@ -325,28 +342,11 @@ Output
 <https://api.istex.fr/ark:/67375/NVC-JMPZTKTT-R> <https://data.istex.fr/ontology/istex#affiliation> "Department of Public Health, University of Sydney, Australia." .
 ```
 
-### ISTEX
+### ISTEXUnzip
 
-Take an array and returns matching documents for every value of the array
+Take the content of a zip file, extract JSON files, and yield JSON objects.
 
-#### Parameters
+The zip file comes from dl.istex.fr, and the `manifest.json` is not
+extracted.
 
--   `query` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** ISTEX query (or queries) (optional, default `data.query||[]`)
--   `id` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** ISTEX id (or ids) (optional, default `data.id||[]`)
--   `maxPage` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** maximum number of pages to get
--   `size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of each page of results
--   `duration` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** maximum duration between two requests (ex: "30s")
--   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** fields to output
-
-#### Examples
-
-```javascript
-.pipe(ezs('ISTEX', {
-  query: 'this is a test',
-  size: 3,
-  maxPage: 1,
-  sid: 'test'
-}))
-```
-
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
+Returns **any** Array<Object>

--- a/docs/plugin-lodex.md
+++ b/docs/plugin-lodex.md
@@ -14,56 +14,36 @@ npm install @ezs/core
 
 #### Table of Contents
 
--   [objects2columns](#objects2columns)
 -   [convertJsonLdToNQuads](#convertjsonldtonquads)
--   [LodexGetFields](#lodexgetfields)
--   [parseNQuads](#parsenquads)
 -   [convertToAtom](#converttoatom)
--   [LodexAggregateQuery](#lodexaggregatequery)
--   [LodexRunQuery](#lodexrunquery)
--   [LodexJoinQuery](#lodexjoinquery)
--   [LodexReduceQuery](#lodexreducequery)
--   [LodexInjectSyndicationFrom](#lodexinjectsyndicationfrom)
--   [Field](#field)
+-   [convertToExtendedJsonLd](#converttoextendedjsonld)
 -   [extractIstexQuery](#extractistexquery)
--   [LodexOutput](#lodexoutput)
--   [LodexGetCharacteristics](#lodexgetcharacteristics)
+-   [Field](#field)
+-   [flattenPatch](#flattenpatch)
+-   [getLastCharacteristic](#getlastcharacteristic)
+-   [getParam](#getparam)
 -   [injectDatasetFields](#injectdatasetfields)
 -   [keyMapping](#keymapping)
--   [LodexBuildContext](#lodexbuildcontext)
--   [flattenPatch](#flattenpatch)
 -   [labelizeFieldID](#labelizefieldid)
--   [getParam](#getparam)
--   [convertToExtendedJsonLd](#converttoextendedjsonld)
--   [getLastCharacteristic](#getlastcharacteristic)
+-   [LodexAggregateQuery](#lodexaggregatequery)
+-   [LodexBuildContext](#lodexbuildcontext)
+-   [LodexGetCharacteristics](#lodexgetcharacteristics)
+-   [LodexGetFields](#lodexgetfields)
 -   [LodexInjectCountFrom](#lodexinjectcountfrom)
+-   [LodexInjectSyndicationFrom](#lodexinjectsyndicationfrom)
+-   [LodexJoinQuery](#lodexjoinquery)
+-   [LodexOutput](#lodexoutput)
+-   [LodexReduceQuery](#lodexreducequery)
+-   [LodexRunQuery](#lodexrunquery)
+-   [objects2columns](#objects2columns)
+-   [parseNQuads](#parsenquads)
 -   [writeTurtle](#writeturtle)
-
-### objects2columns
-
-Take `Object` and ...
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### convertJsonLdToNQuads
 
 Take a JSON-LD object and transform it into NQuads triples.
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### LodexGetFields
-
-Return the fields (the model) of a LODEX.
-
-#### Parameters
-
--   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
-
-### parseNQuads
-
-Take N-Quads string and transform it to Objects.
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### convertToAtom
 
@@ -78,121 +58,16 @@ model.
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
-### LodexAggregateQuery
+### convertToExtendedJsonLd
 
-Take `Object` containing a MongoDB aggregate query and throw the result
+Convert the result of an ISTEX query to an extended JSON-LD.
 
-The input object must contain a `connectionStringURI` property, containing
-the connection string to MongoDB.
-
-#### Parameters
-
--   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
--   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
--   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** MongoDB filter
--   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### LodexRunQuery
-
-Take `Object` containing a MongoDB query and throw the result
-
-The input object must contain a `connectionStringURI` property, containing
-the connection string to MongoDB.
+Every hit must contain the URI of original lodex resource, linked to the
+query.
 
 #### Parameters
 
--   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
--   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
--   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** MongoDB filter
--   `sortOn` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Field to sort on
--   `sortOrder` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Oder to sort
--   `field` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** limit the result to some fields (optional, default `"uri"`)
--   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### LodexJoinQuery
-
-Take 3 parametres and creates a join query (one to many, on sub-ressource)
-
-The input object must contain a `connectionStringURI` property, valued with
-the connection string to MongoDB.
-
-#### Parameters
-
--   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
--   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
--   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** MongoDB filter (optional, default `{}`)
--   `sortOn` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Field to sort on
--   `sortOrder` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Oder to sort
--   `matchField` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Lodex field, containing matchable element
--   `matchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Value used with the match field to get items
--   `joinField` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Lodex field used for the join request
--   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### LodexReduceQuery
-
-Take an `Object` containing a MongoDB query, and a reducer, then throw the
-result.
-
-The input object must contain a `connectionStringURI` property, containing
-the connection string to MongoDB.
-
-#### Parameters
-
--   `reducer` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the reducer to use
--   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
--   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** MongoDB filter (optional, default `{}`)
--   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** limit the result to some fields (optional, default `"uri"`)
--   `minValue` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `maxValue` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `maxSize` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** limit the result (optional, default `1000000`)
--   `orderBy` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** sort the result
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### LodexInjectSyndicationFrom
-
-Inject title & description (syndicationà from field what conatsin the uri of one resource
-
-#### Parameters
-
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Field path contains URI
--   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
-
-#### Examples
-
-Output:
-
-
-```javascript
-[
-  {
-{
-      "id": "uri:/ZD44DSQ",
-      "id-title": "Titre de la ressource uri:/ZD44DSQ",
-      "id-description": "Description de la ressource uri:/ZD44DSQ",
-      "value": 10
-    }
-  }
-]
-```
-
-### Field
-
-Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>
-
-#### Properties
-
--   `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The identifier of the field.
--   `scheme` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The semantic property of the field.
+-   `schemeForIstexQuery` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** URI to put between document and resource
 
 ### extractIstexQuery
 
@@ -216,85 +91,72 @@ Output:
 }
 ```
 
-### LodexOutput
+### Field
 
-Format the output in compliance with LODEX routines format.
+Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>
 
-#### Parameters
+#### Properties
 
--   `keyName` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** name of the `data` property (optional, default `data`)
--   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent or not (optional, default `false`)
--   `extract` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>?** fields to put at the root of the output
-                                      object
+-   `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The identifier of the field.
+-   `scheme` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The semantic property of the field.
 
-#### Examples
+### flattenPatch
 
-Input
+Take `Object` and transform all key ending byu number on array.
 
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-```javascript
-[
-     { _id: 1, value: 2, total: 2 },
-     { _id: 2, value: 4, total: 2 }
-]
-```
+### getLastCharacteristic
 
-Script
-
-
-```javascript
-.pipe(ezs('LodexOutput', { extract: 'total' }))
-```
-
-Output
-
-
-```javascript
-{
-    data [
-        { _id: 1, value: 2 },
-        { _id: 2, value: 4 }
-    ],
-    total: 2
-}
-```
-
-Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### LodexGetCharacteristics
-
-Return the last characteristics (the dataset covering fields) of a LODEX.
-
-#### Parameters
-
--   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
+Get last characteristic (list of all dataset covering fields).
 
 #### Examples
 
-Output:
+Input:
 
 
 ```javascript
 [
   {
-    "characteristics": {
-      "_id": "5d289071340bb500201b5146",
-      "qW6w": "Catégories WOS",
-      "ImiI": "Cette table correspond aux catégories Web Of Science.",
-      "alRS": "/api/run/syndication",
-      "aDLT": "Dans le cadre de l'enrichissement des documents du...",
-      "SFvt": "https://enrichment-process.data.istex.fr/ark:/67375/R0H-PWBRNFQ8-H",
-      "RzXW": "https://docs.google.com/drawings/d/1LzjO-oD6snh0MYfqxfPB7q-LU6Dev1SRmJstXFGzgvg/pub?w=960&h=720",
-      "E4jH": "https://www.etalab.gouv.fr/licence-ouverte-open-licence",
-      "MvkG": "Plateforme ISTEX",
-      "m7G5": "Inist-CNRS",
-      "1TvM": "2016-05-12",
-      "WcNl": "2019-01-16",
-      "publicationDate": "2019-07-12T13:51:45.129Z"
-    }
+    "_id" : ObjectId("5ca32c64019f45001d2b602d"),
+    "publicationDate" : ISODate("2019-04-02T09:33:24.463Z")
+  },
+  {
+    "_id" : ObjectId("5cee50bb019f45001d2b602f"),
+    "publicationDate" : ISODate("2019-05-29T09:28:27.773Z")
+  },
+  {
+    "_id" : ObjectId("5cee5119019f45001d2b6031"),
+    "publicationDate" : ISODate("2019-05-29T09:30:01.319Z")
+  },
+  {
+    "_id" : ObjectId("5cee5153019f45001d2b6032"),
+    "publicationDate" : ISODate("2019-05-29T09:30:59.770Z")
+  },
+  {
+    "_id" : ObjectId("5cee5160019f45001d2b6033"),
+    "publicationDate" : ISODate("2019-05-29T09:31:12.503Z")
+  },
+  {
+    "_id" : ObjectId("5cee530e3e9676001909ba24"),
+    "publicationDate" : ISODate("2019-05-29T09:38:22.569Z")
   }
 ]
 ```
+
+Output:
+
+
+```javascript
+{
+  "_id" : ObjectId("5cee530e3e9676001909ba24"),
+  "publicationDate" : ISODate("2019-05-29T09:38:22.569Z")
+}
+```
+
+Returns **any** 
+
+### getParam
 
 ### injectDatasetFields
 
@@ -376,24 +238,6 @@ Output
 
 Returns **any** Same object with modified keys
 
-### LodexBuildContext
-
-Take `Object` containing a URL query and throw a Context Object
-compatible with runQuery or reduceQuery
-
-#### Parameters
-
--   `connectionStringURI` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** to connect to MongoDB (optional, default `"mongodb://ezmaster_db:27017"`)
--   `host` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** to set host (usefull to build some links)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### flattenPatch
-
-Take `Object` and transform all key ending byu number on array.
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### labelizeFieldID
 
 Inject in each item the last characteristics (the dataset covering fields) of a LODEX.
@@ -433,68 +277,77 @@ Output:
 ]
 ```
 
-### getParam
+### LodexAggregateQuery
 
-### convertToExtendedJsonLd
+Take `Object` containing a MongoDB aggregate query and throw the result
 
-Convert the result of an ISTEX query to an extended JSON-LD.
-
-Every hit must contain the URI of original lodex resource, linked to the
-query.
+The input object must contain a `connectionStringURI` property, containing
+the connection string to MongoDB.
 
 #### Parameters
 
--   `schemeForIstexQuery` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** URI to put between document and resource
+-   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
+-   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
+-   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** MongoDB filter
+-   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
 
-### getLastCharacteristic
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-Get last characteristic (list of all dataset covering fields).
+### LodexBuildContext
+
+Take `Object` containing a URL query and throw a Context Object
+compatible with runQuery or reduceQuery
+
+#### Parameters
+
+-   `connectionStringURI` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** to connect to MongoDB (optional, default `"mongodb://ezmaster_db:27017"`)
+-   `host` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** to set host (usefull to build some links)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### LodexGetCharacteristics
+
+Return the last characteristics (the dataset covering fields) of a LODEX.
+
+#### Parameters
+
+-   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
 
 #### Examples
-
-Input:
-
-
-```javascript
-[
-  {
-    "_id" : ObjectId("5ca32c64019f45001d2b602d"),
-    "publicationDate" : ISODate("2019-04-02T09:33:24.463Z")
-  },
-  {
-    "_id" : ObjectId("5cee50bb019f45001d2b602f"),
-    "publicationDate" : ISODate("2019-05-29T09:28:27.773Z")
-  },
-  {
-    "_id" : ObjectId("5cee5119019f45001d2b6031"),
-    "publicationDate" : ISODate("2019-05-29T09:30:01.319Z")
-  },
-  {
-    "_id" : ObjectId("5cee5153019f45001d2b6032"),
-    "publicationDate" : ISODate("2019-05-29T09:30:59.770Z")
-  },
-  {
-    "_id" : ObjectId("5cee5160019f45001d2b6033"),
-    "publicationDate" : ISODate("2019-05-29T09:31:12.503Z")
-  },
-  {
-    "_id" : ObjectId("5cee530e3e9676001909ba24"),
-    "publicationDate" : ISODate("2019-05-29T09:38:22.569Z")
-  }
-]
-```
 
 Output:
 
 
 ```javascript
-{
-  "_id" : ObjectId("5cee530e3e9676001909ba24"),
-  "publicationDate" : ISODate("2019-05-29T09:38:22.569Z")
-}
+[
+  {
+    "characteristics": {
+      "_id": "5d289071340bb500201b5146",
+      "qW6w": "Catégories WOS",
+      "ImiI": "Cette table correspond aux catégories Web Of Science.",
+      "alRS": "/api/run/syndication",
+      "aDLT": "Dans le cadre de l'enrichissement des documents du...",
+      "SFvt": "https://enrichment-process.data.istex.fr/ark:/67375/R0H-PWBRNFQ8-H",
+      "RzXW": "https://docs.google.com/drawings/d/1LzjO-oD6snh0MYfqxfPB7q-LU6Dev1SRmJstXFGzgvg/pub?w=960&h=720",
+      "E4jH": "https://www.etalab.gouv.fr/licence-ouverte-open-licence",
+      "MvkG": "Plateforme ISTEX",
+      "m7G5": "Inist-CNRS",
+      "1TvM": "2016-05-12",
+      "WcNl": "2019-01-16",
+      "publicationDate": "2019-07-12T13:51:45.129Z"
+    }
+  }
+]
 ```
 
-Returns **any** 
+### LodexGetFields
+
+Return the fields (the model) of a LODEX.
+
+#### Parameters
+
+-   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
 
 ### LodexInjectCountFrom
 
@@ -544,6 +397,153 @@ field = publicationDate
           { id: 7, value:2011, value_count:2  },
 ]
 ````
+
+### LodexInjectSyndicationFrom
+
+Inject title & description (syndicationà from field what conatsin the uri of one resource
+
+#### Parameters
+
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Field path contains URI
+-   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
+
+#### Examples
+
+Output:
+
+
+```javascript
+[
+  {
+{
+      "id": "uri:/ZD44DSQ",
+      "id-title": "Titre de la ressource uri:/ZD44DSQ",
+      "id-description": "Description de la ressource uri:/ZD44DSQ",
+      "value": 10
+    }
+  }
+]
+```
+
+### LodexJoinQuery
+
+Take 3 parametres and creates a join query (one to many, on sub-ressource)
+
+The input object must contain a `connectionStringURI` property, valued with
+the connection string to MongoDB.
+
+#### Parameters
+
+-   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
+-   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
+-   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** MongoDB filter (optional, default `{}`)
+-   `sortOn` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Field to sort on
+-   `sortOrder` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Oder to sort
+-   `matchField` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Lodex field, containing matchable element
+-   `matchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Value used with the match field to get items
+-   `joinField` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Lodex field used for the join request
+-   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### LodexOutput
+
+Format the output in compliance with LODEX routines format.
+
+#### Parameters
+
+-   `keyName` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** name of the `data` property (optional, default `data`)
+-   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent or not (optional, default `false`)
+-   `extract` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>?** fields to put at the root of the output
+                                      object
+
+#### Examples
+
+Input
+
+
+```javascript
+[
+     { _id: 1, value: 2, total: 2 },
+     { _id: 2, value: 4, total: 2 }
+]
+```
+
+Script
+
+
+```javascript
+.pipe(ezs('LodexOutput', { extract: 'total' }))
+```
+
+Output
+
+
+```javascript
+{
+    data [
+        { _id: 1, value: 2 },
+        { _id: 2, value: 4 }
+    ],
+    total: 2
+}
+```
+
+Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### LodexReduceQuery
+
+Take an `Object` containing a MongoDB query, and a reducer, then throw the
+result.
+
+The input object must contain a `connectionStringURI` property, containing
+the connection string to MongoDB.
+
+#### Parameters
+
+-   `reducer` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the reducer to use
+-   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
+-   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** MongoDB filter (optional, default `{}`)
+-   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** limit the result to some fields (optional, default `"uri"`)
+-   `minValue` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `maxValue` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `maxSize` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** limit the result (optional, default `1000000`)
+-   `orderBy` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** sort the result
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### LodexRunQuery
+
+Take `Object` containing a MongoDB query and throw the result
+
+The input object must contain a `connectionStringURI` property, containing
+the connection string to MongoDB.
+
+#### Parameters
+
+-   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
+-   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
+-   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** MongoDB filter
+-   `sortOn` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Field to sort on
+-   `sortOrder` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Oder to sort
+-   `field` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** limit the result to some fields (optional, default `"uri"`)
+-   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### objects2columns
+
+Take `Object` and ...
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### parseNQuads
+
+Take N-Quads string and transform it to Objects.
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### writeTurtle
 

--- a/docs/plugin-lodex.md
+++ b/docs/plugin-lodex.md
@@ -15,21 +15,21 @@ npm install @ezs/core
 #### Table of Contents
 
 -   [objects2columns](#objects2columns)
+-   [convertJsonLdToNQuads](#convertjsonldtonquads)
 -   [LodexGetFields](#lodexgetfields)
 -   [parseNQuads](#parsenquads)
--   [convertJsonLdToNQuads](#convertjsonldtonquads)
 -   [convertToAtom](#converttoatom)
 -   [LodexAggregateQuery](#lodexaggregatequery)
 -   [LodexRunQuery](#lodexrunquery)
 -   [LodexJoinQuery](#lodexjoinquery)
 -   [LodexReduceQuery](#lodexreducequery)
 -   [LodexInjectSyndicationFrom](#lodexinjectsyndicationfrom)
--   [LodexOutput](#lodexoutput)
--   [extractIstexQuery](#extractistexquery)
 -   [Field](#field)
--   [keyMapping](#keymapping)
+-   [extractIstexQuery](#extractistexquery)
+-   [LodexOutput](#lodexoutput)
 -   [LodexGetCharacteristics](#lodexgetcharacteristics)
 -   [injectDatasetFields](#injectdatasetfields)
+-   [keyMapping](#keymapping)
 -   [LodexBuildContext](#lodexbuildcontext)
 -   [flattenPatch](#flattenpatch)
 -   [labelizeFieldID](#labelizefieldid)
@@ -45,6 +45,12 @@ Take `Object` and ...
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### convertJsonLdToNQuads
+
+Take a JSON-LD object and transform it into NQuads triples.
+
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
 ### LodexGetFields
 
 Return the fields (the model) of a LODEX.
@@ -58,12 +64,6 @@ Return the fields (the model) of a LODEX.
 Take N-Quads string and transform it to Objects.
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### convertJsonLdToNQuads
-
-Take a JSON-LD object and transform it into NQuads triples.
-
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ### convertToAtom
 
@@ -185,6 +185,37 @@ Output:
 ]
 ```
 
+### Field
+
+Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>
+
+#### Properties
+
+-   `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The identifier of the field.
+-   `scheme` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The semantic property of the field.
+
+### extractIstexQuery
+
+Extract an ISTEX API query.
+
+#### Parameters
+
+-   `fields` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Field](#field)>** list of LODEX fields (optional, default `[]`)
+
+#### Examples
+
+Output:
+
+
+```javascript
+{
+   content: 'fake query',
+   lodex: {
+      uri: 'http://resource.uri',
+  },
+}
+```
+
 ### LodexOutput
 
 Format the output in compliance with LODEX routines format.
@@ -229,82 +260,6 @@ Output
 ```
 
 Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### extractIstexQuery
-
-Extract an ISTEX API query.
-
-#### Parameters
-
--   `fields` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Field](#field)>** list of LODEX fields (optional, default `[]`)
-
-#### Examples
-
-Output:
-
-
-```javascript
-{
-   content: 'fake query',
-   lodex: {
-      uri: 'http://resource.uri',
-  },
-}
-```
-
-### Field
-
-Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>
-
-#### Properties
-
--   `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The identifier of the field.
--   `scheme` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The semantic property of the field.
-
-### keyMapping
-
-Take an object and map its keys to the one in mapping parameters.
-Keep keys absent in `from` parameter.
-
-#### Parameters
-
--   `from` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** keys of the input
--   `to` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** matching keys for the output
-
-#### Examples
-
-Input:
-
-
-```javascript
-[{
-  "dFgH": "Value",
-  "AaAa": "Value 2"
-}]
-```
-
-EZS:
-
-
-```javascript
-[keyMapping]
-from = dFgH
-to = Title
-from = AaAa
-to = Description
-```
-
-Output
-
-
-```javascript
-[{
-  "Title": "Value",
-  "Description": "Value 2"
-}]
-```
-
-Returns **any** Same object with modified keys
 
 ### LodexGetCharacteristics
 
@@ -375,6 +330,51 @@ Output:
   }
 ]
 ```
+
+### keyMapping
+
+Take an object and map its keys to the one in mapping parameters.
+Keep keys absent in `from` parameter.
+
+#### Parameters
+
+-   `from` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** keys of the input
+-   `to` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** matching keys for the output
+
+#### Examples
+
+Input:
+
+
+```javascript
+[{
+  "dFgH": "Value",
+  "AaAa": "Value 2"
+}]
+```
+
+EZS:
+
+
+```javascript
+[keyMapping]
+from = dFgH
+to = Title
+from = AaAa
+to = Description
+```
+
+Output
+
+
+```javascript
+[{
+  "Title": "Value",
+  "Description": "Value 2"
+}]
+```
+
+Returns **any** Same object with modified keys
 
 ### LodexBuildContext
 

--- a/docs/plugin-loterre.md
+++ b/docs/plugin-loterre.md
@@ -17,9 +17,9 @@ npm install @ezs/loterre
 -   [checkIfPropertyExist](#checkifpropertyexist)
 -   [checkIfPropertyExist](#checkifpropertyexist-1)
 -   [checkIfPropertyExist](#checkifpropertyexist-2)
+-   [writeHierarchy](#writehierarchy)
 -   [getBroaderAndNarrower](#getbroaderandnarrower)
 -   [getBroaderAndNarrower](#getbroaderandnarrower-1)
--   [writeHierarchy](#writehierarchy)
 -   [writeEdge](#writeedge)
 -   [SKOSHierarchy](#skoshierarchy)
 -   [SKOSHierarchy](#skoshierarchy-1)
@@ -48,6 +48,17 @@ npm install @ezs/loterre
 -   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 -   `obj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### writeHierarchy
+
+#### Parameters
+
+-   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
 ### getBroaderAndNarrower
 
 #### Parameters
@@ -67,17 +78,6 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 -   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Returns object
-
-### writeHierarchy
-
-#### Parameters
-
--   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 ### writeEdge
 

--- a/docs/plugin-loterre.md
+++ b/docs/plugin-loterre.md
@@ -17,15 +17,15 @@ npm install @ezs/loterre
 -   [checkIfPropertyExist](#checkifpropertyexist)
 -   [checkIfPropertyExist](#checkifpropertyexist-1)
 -   [checkIfPropertyExist](#checkifpropertyexist-2)
--   [writeHierarchy](#writehierarchy)
 -   [getBroaderAndNarrower](#getbroaderandnarrower)
 -   [getBroaderAndNarrower](#getbroaderandnarrower-1)
--   [writeEdge](#writeedge)
 -   [SKOSHierarchy](#skoshierarchy)
 -   [SKOSHierarchy](#skoshierarchy-1)
 -   [SKOSObject](#skosobject)
 -   [SKOSPathEnum](#skospathenum)
 -   [SKOSPathEnum](#skospathenum-1)
+-   [writeEdge](#writeedge)
+-   [writeHierarchy](#writehierarchy)
 
 ### checkIfPropertyExist
 
@@ -47,17 +47,6 @@ npm install @ezs/loterre
 
 -   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 -   `obj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### writeHierarchy
-
-#### Parameters
-
--   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 ### getBroaderAndNarrower
 
@@ -78,17 +67,6 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 -   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Returns object
-
-### writeEdge
-
-#### Parameters
-
--   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 ### SKOSHierarchy
 
@@ -242,3 +220,25 @@ Output:
 -   `language` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Choose langauge of prefLabel (optional, default `en`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Returns object
+
+### writeEdge
+
+#### Parameters
+
+-   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+### writeHierarchy
+
+#### Parameters
+
+-   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 

--- a/docs/plugin-storage.md
+++ b/docs/plugin-storage.md
@@ -16,23 +16,28 @@ npm install @ezs/storage
 
 #### Table of Contents
 
--   [load](#load)
--   [flow](#flow)
--   [save](#save)
--   [identify](#identify)
 -   [boost](#boost)
+-   [flow](#flow)
+-   [identify](#identify)
+-   [load](#load)
+-   [save](#save)
 
-### load
+### boost
 
-With a `String`, containing a URI throw all the documents that match
+Takes an `Object` delegate processing to an external pipeline and cache the result
 
 #### Parameters
 
 -   `data`  
 -   `feed`  
--   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (that should contains the uri input) (optional, default `ezs`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `key` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the cache key form the stream, in not provided, it's computed with the first chunk
+-   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Frequency (seconds) to cleanup the cache (EZS_DELAY) (optional, default `3600`)
 
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### flow
 
@@ -45,20 +50,6 @@ Warning: order is not guaranteed
 -   `feed`  
 -   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (same for all objects) (optional, default `ezs`)
 -   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** limit the number of output objects
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### save
-
-Take `Object`, to save it into a store and throw an URL
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path containing the object Identifier (optional, default `uri`)
--   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (same for all objects) (optional, default `ezs`)
--   `reset` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** if the store already exists, you will erase all previous content (optional, default `false`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -75,19 +66,28 @@ Take `Object`, and compute & add a identifier
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
-### boost
+### load
 
-Takes an `Object` delegate processing to an external pipeline and cache the result
+With a `String`, containing a URI throw all the documents that match
 
 #### Parameters
 
 -   `data`  
 -   `feed`  
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `key` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the cache key form the stream, in not provided, it's computed with the first chunk
--   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Frequency (seconds) to cleanup the cache (EZS_DELAY) (optional, default `3600`)
+-   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (that should contains the uri input) (optional, default `ezs`)
+
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### save
+
+Take `Object`, to save it into a store and throw an URL
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path containing the object Identifier (optional, default `uri`)
+-   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (same for all objects) (optional, default `ezs`)
+-   `reset` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** if the store already exists, you will erase all previous content (optional, default `false`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/docs/plugin-transformers.md
+++ b/docs/plugin-transformers.md
@@ -85,34 +85,34 @@ npm install @ezs/transformers
 -   [$ARRAY](#array)
 -   [$BOOLEAN](#boolean)
 -   [$CAPITALIZE](#capitalize)
+-   [$COLUMN](#column)
+-   [$CONCAT](#concat)
+-   [$CONCAT_URI](#concat_uri)
+-   [$DEFAULT](#default)
 -   [$FORMAT](#format)
+-   [$GET](#get)
+-   [$JOIN](#join)
 -   [$LOWERCASE](#lowercase)
+-   [$MAPPING](#mapping)
+-   [$MASK](#mask)
 -   [$NUMBER](#number)
 -   [$PARSE](#parse)
+-   [$PREFIX](#prefix)
+-   [$REMOVE](#remove)
+-   [$REPLACE](#replace)
+-   [$REPLACE_REGEX](#replace_regex)
+-   [$SELECT](#select)
+-   [$SHIFT](#shift)
+-   [$SPLIT](#split)
 -   [$STRING](#string)
+-   [$SUFFIX](#suffix)
 -   [$TRIM](#trim)
+-   [$TRUNCATE](#truncate)
+-   [$TRUNCATE_WORDS](#truncate_words)
 -   [$UNIQ](#uniq)
 -   [$UPPERCASE](#uppercase)
 -   [$URLENCODE](#urlencode)
--   [$COLUMN](#column)
--   [$DEFAULT](#default)
--   [$GET](#get)
--   [$JOIN](#join)
--   [$MASK](#mask)
--   [$PREFIX](#prefix)
--   [$REMOVE](#remove)
--   [$SHIFT](#shift)
--   [$SUFFIX](#suffix)
 -   [$VALUE](#value)
--   [$CONCAT](#concat)
--   [$MAPPING](#mapping)
--   [$SELECT](#select)
--   [$SPLIT](#split)
--   [$TRUNCATE_WORDS](#truncate_words)
--   [$TRUNCATE](#truncate)
--   [$CONCAT_URI](#concat_uri)
--   [$REPLACE_REGEX](#replace_regex)
--   [$REPLACE](#replace)
 
 ### $ARRAY
 
@@ -171,6 +171,94 @@ field = title
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### $COLUMN
+
+prendre une donnée dans un champ (colonne d'un fichier tabulé)
+
+Exemple :
+
+```ini
+[$COLUMN]
+field = newTitle
+column = oldTitle
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $CONCAT
+
+concaténer deux valeurs
+
+Exemple :
+
+```ini
+[$CONCAT]
+field = result
+columns = part1
+columns = part2
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
+-   `columns` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $CONCAT_URI
+
+compoer un identifiant avec plusieurs champs
+
+Exemple :
+
+```ini
+[$CONCAT_URI]
+field = identifiant
+column = nom
+column = prenom
+separator = -
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
+-   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get data
+-   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** glue between each column
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $DEFAULT
+
+donner une valeur par défaut
+
+Exemple :
+
+```ini
+[$DEFAULT]
+field = title
+alternative = not available
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `alternative` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use if field does not exist
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### $FORMAT
 
 appliquer un patron (template)
@@ -190,6 +278,48 @@ with = (%s:%s)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### $GET
+
+Récupére toutes les valeurs correspondant à un chemin (dot path)
+
+ Exemple :
+
+```ini
+[$GET]
+field = output
+path = input
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $JOIN
+
+Rassemble les valeurs d'un tableau en une chaîne de caractères
+
+ Exemple :
+
+```ini
+[$JOIN]
+field = output
+path = input
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation (must be an array)
+-   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** glue between each field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### $LOWERCASE
 
 mettre en bas de casse (minuscules)
@@ -206,6 +336,49 @@ field = title
 -   `data`  
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $MAPPING
+
+Opération permettant le remplacement à partir d'une table
+(équivalent à l'enchaînement de plusieurs opération REPLACE)
+
+Exemple :
+
+```ini
+[$MAPPING]
+field = keywords
+list = "hello":"bonjour", "hi":"salut"
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `list` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the mapping list
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $MASK
+
+S'assure que la valeur respecte une expression régulière
+
+Exemple :
+
+```ini
+[$MASK]
+field = title
+with = ^[a-z]+$
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the control
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -247,6 +420,157 @@ field = json
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### $PREFIX
+
+préfixer la valeur avec une chaîne de caractères
+
+Exemple :
+
+```ini
+[$PREFIX]
+field = title
+with = #
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `vith` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the begining of the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $REMOVE
+
+supprimer un élément ou une sous-chaîne
+
+Exemple :
+
+```ini
+[$REMOVE]
+field = title
+the = .
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `the` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value todrop in the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $REPLACE
+
+remplacer une chaîne par une autre
+
+Exemple :
+
+```ini
+[$REPLACE]
+field = title
+searchValue = 1
+replaceValue = un
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to search
+-   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $REPLACE_REGEX
+
+remplacer une chaîne par une autre via une exrpression régulière
+
+Exemple :
+
+```ini
+[$REPLACE_REGEX]
+field = title
+searchValue = $hel\w+
+replaceValue = bonjour
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** regex to search
+-   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SELECT
+
+Prendre une valeir dans un objet à partir de son chemin (dot path)
+
+Exemple :
+
+```ini
+[$SELECT]
+field = title
+path
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the selection
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SHIFT
+
+décaler une valeur multiple (tableau ou chaîne de caractères)
+
+Exemple :
+
+```ini
+[$SHIFT]
+field = title
+gap = 2
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many item or characters to drop
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SPLIT
+
+segmente une chaîne de caractères en tableau
+
+Exemple :
+
+```ini
+[$SPLIT]
+field = title
+separator = |
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to split the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### $STRING
 
 transforme la valeur en chaîne de caractères
@@ -266,6 +590,27 @@ field = title
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### $SUFFIX
+
+ajoute une chaîne de caractères à la fin d'une chaîne ou d'un tableau
+
+Exemple :
+
+```ini
+[$SUFFIX]
+field = title
+with = !
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `with` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the end of the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### $TRIM
 
 enlève les espaces au début et à la fin d'une chaîne de caractères
@@ -282,6 +627,49 @@ field = title
 -   `data`  
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $TRUNCATE
+
+tronque, prend les premières valeurs d'un tableau, d'une chaîne
+
+Exemple :
+
+```ini
+[$TRUNCATE]
+field = title
+gap = 25
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many items or characters to keep
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $TRUNCATE_WORDS
+
+Opération permettant la troncature par nombre de mots
+et non pas par nombre de caractères comme pour opération TRUNCATE
+
+Exemple :
+
+```ini
+[$TRUNCATE_WORDS]
+field = title
+gap = 10
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many words to keep
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -342,195 +730,6 @@ field = url
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $COLUMN
-
-prendre une donnée dans un champ (colonne d'un fichier tabulé)
-
-Exemple :
-
-```ini
-[$COLUMN]
-field = newTitle
-column = oldTitle
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $DEFAULT
-
-donner une valeur par défaut
-
-Exemple :
-
-```ini
-[$DEFAULT]
-field = title
-alternative = not available
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `alternative` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use if field does not exist
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $GET
-
-Récupére toutes les valeurs correspondant à un chemin (dot path)
-
- Exemple :
-
-```ini
-[$GET]
-field = output
-path = input
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $JOIN
-
-Rassemble les valeurs d'un tableau en une chaîne de caractères
-
- Exemple :
-
-```ini
-[$JOIN]
-field = output
-path = input
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation (must be an array)
--   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** glue between each field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $MASK
-
-S'assure que la valeur respecte une expression régulière
-
-Exemple :
-
-```ini
-[$MASK]
-field = title
-with = ^[a-z]+$
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the control
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $PREFIX
-
-préfixer la valeur avec une chaîne de caractères
-
-Exemple :
-
-```ini
-[$PREFIX]
-field = title
-with = #
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `vith` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the begining of the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $REMOVE
-
-supprimer un élément ou une sous-chaîne
-
-Exemple :
-
-```ini
-[$REMOVE]
-field = title
-the = .
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `the` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value todrop in the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SHIFT
-
-décaler une valeur multiple (tableau ou chaîne de caractères)
-
-Exemple :
-
-```ini
-[$SHIFT]
-field = title
-gap = 2
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many item or characters to drop
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SUFFIX
-
-ajoute une chaîne de caractères à la fin d'une chaîne ou d'un tableau
-
-Exemple :
-
-```ini
-[$SUFFIX]
-field = title
-with = !
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `with` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the end of the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### $VALUE
 
 Fixer une valeur
@@ -549,204 +748,5 @@ value = Hello world
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** new field path
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to set the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $CONCAT
-
-concaténer deux valeurs
-
-Exemple :
-
-```ini
-[$CONCAT]
-field = result
-columns = part1
-columns = part2
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
--   `columns` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $MAPPING
-
-Opération permettant le remplacement à partir d'une table
-(équivalent à l'enchaînement de plusieurs opération REPLACE)
-
-Exemple :
-
-```ini
-[$MAPPING]
-field = keywords
-list = "hello":"bonjour", "hi":"salut"
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `list` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the mapping list
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SELECT
-
-Prendre une valeir dans un objet à partir de son chemin (dot path)
-
-Exemple :
-
-```ini
-[$SELECT]
-field = title
-path
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the selection
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SPLIT
-
-segmente une chaîne de caractères en tableau
-
-Exemple :
-
-```ini
-[$SPLIT]
-field = title
-separator = |
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to split the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $TRUNCATE_WORDS
-
-Opération permettant la troncature par nombre de mots
-et non pas par nombre de caractères comme pour opération TRUNCATE
-
-Exemple :
-
-```ini
-[$TRUNCATE_WORDS]
-field = title
-gap = 10
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many words to keep
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $TRUNCATE
-
-tronque, prend les premières valeurs d'un tableau, d'une chaîne
-
-Exemple :
-
-```ini
-[$TRUNCATE]
-field = title
-gap = 25
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many items or characters to keep
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $CONCAT_URI
-
-compoer un identifiant avec plusieurs champs
-
-Exemple :
-
-```ini
-[$CONCAT_URI]
-field = identifiant
-column = nom
-column = prenom
-separator = -
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
--   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get data
--   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** glue between each column
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $REPLACE_REGEX
-
-remplacer une chaîne par une autre via une exrpression régulière
-
-Exemple :
-
-```ini
-[$REPLACE_REGEX]
-field = title
-searchValue = $hel\w+
-replaceValue = bonjour
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** regex to search
--   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $REPLACE
-
-remplacer une chaîne par une autre
-
-Exemple :
-
-```ini
-[$REPLACE]
-field = title
-searchValue = 1
-replaceValue = un
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to search
--   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/docs/plugin-transformers.md
+++ b/docs/plugin-transformers.md
@@ -82,56 +82,37 @@ npm install @ezs/transformers
 
 #### Table of Contents
 
--   [$LOWERCASE](#lowercase)
 -   [$ARRAY](#array)
--   [$TRIM](#trim)
--   [$URLENCODE](#urlencode)
--   [$UPPERCASE](#uppercase)
--   [$FORMAT](#format)
+-   [$BOOLEAN](#boolean)
 -   [$CAPITALIZE](#capitalize)
--   [$UNIQ](#uniq)
+-   [$FORMAT](#format)
+-   [$LOWERCASE](#lowercase)
 -   [$NUMBER](#number)
 -   [$PARSE](#parse)
--   [$BOOLEAN](#boolean)
 -   [$STRING](#string)
+-   [$TRIM](#trim)
+-   [$UNIQ](#uniq)
+-   [$UPPERCASE](#uppercase)
+-   [$URLENCODE](#urlencode)
 -   [$COLUMN](#column)
+-   [$DEFAULT](#default)
 -   [$GET](#get)
 -   [$JOIN](#join)
--   [$DEFAULT](#default)
--   [$REMOVE](#remove)
--   [$VALUE](#value)
--   [$SUFFIX](#suffix)
 -   [$MASK](#mask)
--   [$SHIFT](#shift)
 -   [$PREFIX](#prefix)
--   [$SPLIT](#split)
+-   [$REMOVE](#remove)
+-   [$SHIFT](#shift)
+-   [$SUFFIX](#suffix)
+-   [$VALUE](#value)
+-   [$CONCAT](#concat)
+-   [$MAPPING](#mapping)
 -   [$SELECT](#select)
+-   [$SPLIT](#split)
 -   [$TRUNCATE_WORDS](#truncate_words)
 -   [$TRUNCATE](#truncate)
--   [$MAPPING](#mapping)
--   [$CONCAT](#concat)
 -   [$CONCAT_URI](#concat_uri)
--   [$REPLACE](#replace)
 -   [$REPLACE_REGEX](#replace_regex)
-
-### $LOWERCASE
-
-mettre en bas de casse (minuscules)
-
-Exemple :
-
-```ini
-[$LOWERCASE]
-field = title
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   [$REPLACE](#replace)
 
 ### $ARRAY
 
@@ -152,15 +133,15 @@ field = keywords
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $TRIM
+### $BOOLEAN
 
-enlève les espaces au début et à la fin d'une chaîne de caractères
+transformer une chaîne de caractères en booléen
 
 Exemple :
 
 ```ini
-[$TRIM]
-field = title
+[$BOOLEAN]
+field = haveMoney
 ```
 
 #### Parameters
@@ -171,33 +152,14 @@ field = title
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $URLENCODE
+### $CAPITALIZE
 
-encode une chaine comme dans une URL
-
-Exemple :
-
-```ini
-[$URLENCODE]
-field = url
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $UPPERCASE
-
-mettre la chaîne en majuscules
+mettre le premier caractère en majuscule
 
 Exemple :
 
 ```ini
-[$UPPERCASE]
+[$CAPITALIZE]
 field = title
 ```
 
@@ -228,14 +190,14 @@ with = (%s:%s)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $CAPITALIZE
+### $LOWERCASE
 
-mettre le premier caractère en majuscule
+mettre en bas de casse (minuscules)
 
 Exemple :
 
 ```ini
-[$CAPITALIZE]
+[$LOWERCASE]
 field = title
 ```
 
@@ -244,25 +206,6 @@ field = title
 -   `data`  
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $UNIQ
-
-dédoublonne les valeurs (dans un tableau)
-
-Exemple :
-
-```ini
-[$UNIQ]
-field = title
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation (must be an aarray)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -304,15 +247,15 @@ field = json
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $BOOLEAN
+### $STRING
 
-transformer une chaîne de caractères en booléen
+transforme la valeur en chaîne de caractères
 
 Exemple :
 
 ```ini
-[$BOOLEAN]
-field = haveMoney
+[$STRING]
+field = title
 ```
 
 #### Parameters
@@ -323,15 +266,72 @@ field = haveMoney
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $STRING
+### $TRIM
 
-transforme la valeur en chaîne de caractères
+enlève les espaces au début et à la fin d'une chaîne de caractères
 
 Exemple :
 
 ```ini
-[$STRING]
+[$TRIM]
 field = title
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $UNIQ
+
+dédoublonne les valeurs (dans un tableau)
+
+Exemple :
+
+```ini
+[$UNIQ]
+field = title
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation (must be an aarray)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $UPPERCASE
+
+mettre la chaîne en majuscules
+
+Exemple :
+
+```ini
+[$UPPERCASE]
+field = title
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $URLENCODE
+
+encode une chaine comme dans une URL
+
+Exemple :
+
+```ini
+[$URLENCODE]
+field = url
 ```
 
 #### Parameters
@@ -360,6 +360,27 @@ column = oldTitle
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
 -   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $DEFAULT
+
+donner une valeur par défaut
+
+Exemple :
+
+```ini
+[$DEFAULT]
+field = title
+alternative = not available
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `alternative` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use if field does not exist
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -405,90 +426,6 @@ path = input
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $DEFAULT
-
-donner une valeur par défaut
-
-Exemple :
-
-```ini
-[$DEFAULT]
-field = title
-alternative = not available
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `alternative` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use if field does not exist
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $REMOVE
-
-supprimer un élément ou une sous-chaîne
-
-Exemple :
-
-```ini
-[$REMOVE]
-field = title
-the = .
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `the` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value todrop in the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $VALUE
-
-Fixer une valeur
-
-Exemple :
-
-```ini
-[$VALUE]
-field = title
-value = Hello world
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** new field path
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to set the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SUFFIX
-
-ajoute une chaîne de caractères à la fin d'une chaîne ou d'un tableau
-
-Exemple :
-
-```ini
-[$SUFFIX]
-field = title
-with = !
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `with` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the end of the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### $MASK
 
 S'assure que la valeur respecte une expression régulière
@@ -507,27 +444,6 @@ with = ^[a-z]+$
 -   `feed`  
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the control
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SHIFT
-
-décaler une valeur multiple (tableau ou chaîne de caractères)
-
-Exemple :
-
-```ini
-[$SHIFT]
-field = title
-gap = 2
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many item or characters to drop
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -552,16 +468,58 @@ with = #
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $SPLIT
+### $REMOVE
 
-segmente une chaîne de caractères en tableau
+supprimer un élément ou une sous-chaîne
 
 Exemple :
 
 ```ini
-[$SPLIT]
+[$REMOVE]
 field = title
-separator = |
+the = .
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `the` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value todrop in the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SHIFT
+
+décaler une valeur multiple (tableau ou chaîne de caractères)
+
+Exemple :
+
+```ini
+[$SHIFT]
+field = title
+gap = 2
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many item or characters to drop
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SUFFIX
+
+ajoute une chaîne de caractères à la fin d'une chaîne ou d'un tableau
+
+Exemple :
+
+```ini
+[$SUFFIX]
+field = title
+with = !
 ```
 
 #### Parameters
@@ -569,7 +527,72 @@ separator = |
 -   `data`  
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to split the field
+-   `with` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the end of the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $VALUE
+
+Fixer une valeur
+
+Exemple :
+
+```ini
+[$VALUE]
+field = title
+value = Hello world
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** new field path
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to set the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $CONCAT
+
+concaténer deux valeurs
+
+Exemple :
+
+```ini
+[$CONCAT]
+field = result
+columns = part1
+columns = part2
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
+-   `columns` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $MAPPING
+
+Opération permettant le remplacement à partir d'une table
+(équivalent à l'enchaînement de plusieurs opération REPLACE)
+
+Exemple :
+
+```ini
+[$MAPPING]
+field = keywords
+list = "hello":"bonjour", "hi":"salut"
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `list` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the mapping list
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -591,6 +614,27 @@ path
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the selection
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SPLIT
+
+segmente une chaîne de caractères en tableau
+
+Exemple :
+
+```ini
+[$SPLIT]
+field = title
+separator = |
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to split the field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -637,50 +681,6 @@ gap = 25
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $MAPPING
-
-Opération permettant le remplacement à partir d'une table
-(équivalent à l'enchaînement de plusieurs opération REPLACE)
-
-Exemple :
-
-```ini
-[$MAPPING]
-field = keywords
-list = "hello":"bonjour", "hi":"salut"
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `list` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the mapping list
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $CONCAT
-
-concaténer deux valeurs
-
-Exemple :
-
-```ini
-[$CONCAT]
-field = result
-columns = part1
-columns = part2
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
--   `columns` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### $CONCAT_URI
 
 compoer un identifiant avec plusieurs champs
@@ -705,29 +705,6 @@ separator = -
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $REPLACE
-
-remplacer une chaîne par une autre
-
-Exemple :
-
-```ini
-[$REPLACE]
-field = title
-searchValue = 1
-replaceValue = un
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to search
--   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### $REPLACE_REGEX
 
 remplacer une chaîne par une autre via une exrpression régulière
@@ -747,6 +724,29 @@ replaceValue = bonjour
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
 -   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** regex to search
+-   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $REPLACE
+
+remplacer une chaîne par une autre
+
+Exemple :
+
+```ini
+[$REPLACE]
+field = title
+searchValue = 1
+replaceValue = un
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to search
 -   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -21,15 +21,15 @@ npm install @ezs/analytics
 -   [files](#files)
 -   [buffers](#buffers)
 -   [maximizing](#maximizing)
+-   [bufferize](#bufferize)
 -   [groupingByModulo](#groupingbymodulo)
 -   [reducing](#reducing)
--   [bufferize](#bufferize)
 -   [aggregate](#aggregate)
 -   [slice](#slice)
+-   [distinct](#distinct)
+-   [exploding](#exploding)
 -   [graph](#graph)
 -   [upload](#upload)
--   [exploding](#exploding)
--   [distinct](#distinct)
 -   [pair](#pair)
 -   [merging](#merging)
 -   [summing](#summing)
@@ -38,19 +38,19 @@ npm install @ezs/analytics
 -   [greater](#greater)
 -   [pluck](#pluck)
 -   [drop](#drop)
--   [groupingByLevenshtein](#groupingbylevenshtein)
 -   [groupingByHamming](#groupingbyhamming)
+-   [groupingByLevenshtein](#groupingbylevenshtein)
 -   [keys](#keys)
--   [tune](#tune)
 -   [groupingByEquality](#groupingbyequality)
+-   [tune](#tune)
 -   [multiply](#multiply)
 -   [less](#less)
 -   [count](#count)
--   [sort](#sort)
 -   [distribute](#distribute)
+-   [sort](#sort)
 -   [combine](#combine)
--   [expand](#expand)
 -   [distance](#distance)
+-   [expand](#expand)
 -   [segment](#segment)
 -   [statistics](#statistics)
 
@@ -243,6 +243,44 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### bufferize
+
+Takes all `Objects` and bufferize them in a store
+
+```json
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[bufferize]
+path = bufferID
+```
+
+Output:
+
+```json
+ [
+          { year: 2000, dept: 54, bufferID: 'AEERRFFF' },
+          { year: 2001, dept: 55, bufferID: 'AEERRFFF' },
+          { year: 2003, dept: 54, bufferID: 'AEERRFFF' },
+ ]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the path to insert the bufferID (optional, default `bufferID`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### groupingByModulo
 
 Take `Object` like `{ id, value }` and reduce all `value`s with the same
@@ -311,44 +349,6 @@ Output:
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### bufferize
-
-Takes all `Objects` and bufferize them in a store
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[bufferize]
-path = bufferID
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: 54, bufferID: 'AEERRFFF' },
-          { year: 2001, dept: 55, bufferID: 'AEERRFFF' },
-          { year: 2003, dept: 54, bufferID: 'AEERRFFF' },
- ]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the path to insert the bufferID (optional, default `bufferID`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -434,6 +434,90 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### distinct
+
+Take `Object` object getting some fields with json path, and do ...
+
+```json
+[{
+          { a: 'x', b: 'z' },
+          { a: 't', b: 'z' },
+          { a: 't', b: 'z' },
+          { a: 'x', b: 'z' },
+          { a: 'x', b: 'z' },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[distinct]
+path = a
+```
+
+Output:
+
+```json
+[
+          { id: 'x', value: 1 },
+          { id: 't', value: 1 },
+          { id: 't', value: 1 },
+          { id: 'x', value: 1 },
+          { id: 'x', value: 1 },
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `"id"`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### exploding
+
+Take `Object` and take values with [value] path (must be an array)
+and throw object of each value. The new object is build with [id] and eac value.
+
+```json
+[
+ { departure: ['tokyo', 'nancy'], arrival: 'toul' },
+ { departure: ['paris', 'nancy'], arrival: 'toul' },
+ { departure: ['london', 'berlin'], arrival: 'toul' },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[exploding]
+```
+
+Output:
+
+```json
+[
+   { "id": "toul", "value": "tokyo" },
+   { "id": "toul", "value": "nancy" },
+   { "id": "toul", "value": "paris" },
+   { "id": "toul", "value": "nancy" },
+   { "id": "toul", "value": "london" },
+   { "id": "toul", "value": "berlin" }
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### graph
 
 Take `Object` and throw a new special object (id, value) for each combination of values
@@ -512,90 +596,6 @@ Output:
 -   `extension` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file extension (optional, default `bin`)
 -   `prefix` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file prefix (optional, default `upload`)
 -   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** TTL in seconds, before cleanup the file (EZS_DELAY) (optional, default `3600`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### exploding
-
-Take `Object` and take values with [value] path (must be an array)
-and throw object of each value. The new object is build with [id] and eac value.
-
-```json
-[
- { departure: ['tokyo', 'nancy'], arrival: 'toul' },
- { departure: ['paris', 'nancy'], arrival: 'toul' },
- { departure: ['london', 'berlin'], arrival: 'toul' },
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[exploding]
-```
-
-Output:
-
-```json
-[
-   { "id": "toul", "value": "tokyo" },
-   { "id": "toul", "value": "nancy" },
-   { "id": "toul", "value": "paris" },
-   { "id": "toul", "value": "nancy" },
-   { "id": "toul", "value": "london" },
-   { "id": "toul", "value": "berlin" }
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### distinct
-
-Take `Object` object getting some fields with json path, and do ...
-
-```json
-[{
-          { a: 'x', b: 'z' },
-          { a: 't', b: 'z' },
-          { a: 't', b: 'z' },
-          { a: 'x', b: 'z' },
-          { a: 'x', b: 'z' },
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[distinct]
-path = a
-```
-
-Output:
-
-```json
-[
-          { id: 'x', value: 1 },
-          { id: 't', value: 1 },
-          { id: 't', value: 1 },
-          { id: 'x', value: 1 },
-          { id: 'x', value: 1 },
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `"id"`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -961,53 +961,6 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### groupingByLevenshtein
-
-Take `Object` like `{ id, value }` and reduce all `value`s with
-`id` which have the same Levenshtein distance in a single object
-
-```json
-[
-   { "id": "lorem", "value": 1 },
-   { "id": "Lorem", "value": 1 },
-   { "id": "loren", "value": 1 },
-   { "id": "korem", "value": 1 },
-   { "id": "olrem", "value": 1 },
-   { "id": "toto", "value": 1 },
-   { "id": "titi", "value": 1 },
-   { "id": "lorem", "value": 1 }
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[groupingByLevenshtein]
-distance = 2
-
-[summing]
-```
-
-Output:
-
-```json
-[
-   { "id": [ "lorem", "Lorem", "loren", "korem", "olrem" ], "value": 6 },
-   { "id": [ "toto", "titi" ], "value": 2 }
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
--   `distance` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** minimal levenshtein distance to have a same id (optional, default `1`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### groupingByHamming
 
 Take `Object` like `{ id, value }` and reduce all `value` with `id` which
@@ -1052,6 +1005,53 @@ Output:
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### groupingByLevenshtein
+
+Take `Object` like `{ id, value }` and reduce all `value`s with
+`id` which have the same Levenshtein distance in a single object
+
+```json
+[
+   { "id": "lorem", "value": 1 },
+   { "id": "Lorem", "value": 1 },
+   { "id": "loren", "value": 1 },
+   { "id": "korem", "value": 1 },
+   { "id": "olrem", "value": 1 },
+   { "id": "toto", "value": 1 },
+   { "id": "titi", "value": 1 },
+   { "id": "lorem", "value": 1 }
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[groupingByLevenshtein]
+distance = 2
+
+[summing]
+```
+
+Output:
+
+```json
+[
+   { "id": [ "lorem", "Lorem", "loren", "korem", "olrem" ], "value": 6 },
+   { "id": [ "toto", "titi" ], "value": 2 }
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `distance` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** minimal levenshtein distance to have a same id (optional, default `1`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1108,37 +1108,6 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### tune
-
-Take all `Object` and sort them with selected field
-
-```json
-[{
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[tune]
-```
-
-Output:
-
-```json
-[
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for the sort key (optional, default `id`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### groupingByEquality
 
 Take `Object` like `{ id, value }` and reduce all values with the same `id`
@@ -1186,6 +1155,37 @@ Output:
 
 -   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### tune
+
+Take all `Object` and sort them with selected field
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[tune]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for the sort key (optional, default `id`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1360,56 +1360,6 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### sort
-
-Take all `Object` and sort them with dedicated key
-
-```json
-[{
- { id: 2000, value: 1 },
- { id: 2001, value: 2 },
- { id: 2003, value: 3 },
- { id: 2005, value: 4 },
- { id: 2007, value: 5 },
- { id: 2009, value: 6 },
- { id: 2011, value: 7 },
- { id: 2013, value: 8 },
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[sort]
-path = value
-reverse = true
-```
-
-Output:
-
-```json
-[
-{ "id": 2013, "value": 8 },
-{ "id": 2011, "value": 7 },
-{ "id": 2009, "value": 6 },
-{ "id": 2007, "value": 5 },
-{ "id": 2005, "value": 4 },
-{ "id": 2003, "value": 3 },
-{ "id": 2001, "value": 2 },
-{ "id": 2000, "value": 1 }
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `reverse` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** reverser order (optional, default `false`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### distribute
 
 Take `Object` like { id, value } and throw a serie of number value
@@ -1468,6 +1418,56 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### sort
+
+Take all `Object` and sort them with dedicated key
+
+```json
+[{
+ { id: 2000, value: 1 },
+ { id: 2001, value: 2 },
+ { id: 2003, value: 3 },
+ { id: 2005, value: 4 },
+ { id: 2007, value: 5 },
+ { id: 2009, value: 6 },
+ { id: 2011, value: 7 },
+ { id: 2013, value: 8 },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[sort]
+path = value
+reverse = true
+```
+
+Output:
+
+```json
+[
+{ "id": 2013, "value": 8 },
+{ "id": 2011, "value": 7 },
+{ "id": 2009, "value": 6 },
+{ "id": 2007, "value": 5 },
+{ "id": 2005, "value": 4 },
+{ "id": 2003, "value": 3 },
+{ "id": 2001, "value": 2 },
+{ "id": 2000, "value": 1 }
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `reverse` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** reverser order (optional, default `false`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### combine
 
 Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
@@ -1513,53 +1513,6 @@ Output:
 -   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
 -   `persistent` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The internal database will be reused until it is deleted (optional, default `false`)
 -   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### expand
-
-Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
-the internal pipeline receive a special object { id, value } id is the item identifier & value is the item path value
-The internal pipeline can expand value with another
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[expand]
-path = dept
-file = ./departement.ini
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
-          { year: 2001, dept: { id: 55, value: 'Meuse' } },
-          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
- ]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
--   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** How many chunk for sending to the external pipeline (optional, default `1`)
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `cacheName` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Enable cache, with dedicated name
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1634,6 +1587,53 @@ Output:
 #### Parameters
 
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### expand
+
+Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
+the internal pipeline receive a special object { id, value } id is the item identifier & value is the item path value
+The internal pipeline can expand value with another
+
+```json
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[expand]
+path = dept
+file = ./departement.ini
+```
+
+Output:
+
+```json
+ [
+          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
+          { year: 2001, dept: { id: 55, value: 'Meuse' } },
+          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
+ ]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
+-   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** How many chunk for sending to the external pipeline (optional, default `1`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `cacheName` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Enable cache, with dedicated name
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -16,97 +16,54 @@ npm install @ezs/analytics
 
 #### Table of Contents
 
--   [output](#output)
--   [minimizing](#minimizing)
--   [files](#files)
--   [buffers](#buffers)
--   [maximizing](#maximizing)
--   [bufferize](#bufferize)
--   [groupingByModulo](#groupingbymodulo)
--   [reducing](#reducing)
 -   [aggregate](#aggregate)
--   [slice](#slice)
+-   [bufferize](#bufferize)
+-   [buffers](#buffers)
+-   [combine](#combine)
+-   [count](#count)
+-   [distance](#distance)
 -   [distinct](#distinct)
--   [exploding](#exploding)
--   [graph](#graph)
--   [upload](#upload)
--   [pair](#pair)
--   [merging](#merging)
--   [summing](#summing)
--   [filter](#filter)
--   [value](#value)
--   [greater](#greater)
--   [pluck](#pluck)
+-   [distribute](#distribute)
 -   [drop](#drop)
+-   [expand](#expand)
+-   [exploding](#exploding)
+-   [files](#files)
+-   [filter](#filter)
+-   [graph](#graph)
+-   [greater](#greater)
+-   [groupingByEquality](#groupingbyequality)
 -   [groupingByHamming](#groupingbyhamming)
 -   [groupingByLevenshtein](#groupingbylevenshtein)
+-   [groupingByModulo](#groupingbymodulo)
 -   [keys](#keys)
--   [groupingByEquality](#groupingbyequality)
--   [tune](#tune)
--   [multiply](#multiply)
 -   [less](#less)
--   [count](#count)
--   [distribute](#distribute)
--   [sort](#sort)
--   [combine](#combine)
--   [distance](#distance)
--   [expand](#expand)
+-   [maximizing](#maximizing)
+-   [merging](#merging)
+-   [minimizing](#minimizing)
+-   [multiply](#multiply)
+-   [output](#output)
+-   [pair](#pair)
+-   [pluck](#pluck)
+-   [reducing](#reducing)
 -   [segment](#segment)
+-   [slice](#slice)
+-   [sort](#sort)
 -   [statistics](#statistics)
+-   [summing](#summing)
+-   [tune](#tune)
+-   [upload](#upload)
+-   [value](#value)
 
-### output
+### aggregate
 
-Format the output with data a meta
-
-#### Parameters
-
--   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent or not (optional, default `false`)
--   `meta` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>?** fields to be considered as metadata
-                                      object
-
-#### Examples
-
-Input
-
-
-```javascript
-[
-     { _id: 1, value: 2, total: 2 },
-     { _id: 2, value: 4, total: 2 }
-]
-```
-
-Script
-
-
-```javascript
-.pipe(ezs('output', { meta: 'total' }))
-```
-
-Output
-
-
-```javascript
-{
-    data: [
-        { _id: 1, value: 2 },
-        { _id: 2, value: 4 }
-    ],
-    meta: {
-        total: 2
-    }
-}
-```
-
-Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### minimizing
-
-Take special `Object` like `{id, value}` and replace `value` with the min of
-`value`s
+Aggregate by id and count
 
 ```json
 [{
+         { id: 'x', value: 2 },
+         { id: 't', value: 2 },
+         { id: 'x', value: 3 },
+         { id: 'x', value: 5 },
 }]
 ```
 
@@ -116,130 +73,23 @@ Script:
 [use]
 plugin = analytics
 
-[drop]
+[aggregate]
+path = id
 ```
 
 Output:
 
 ```json
 [
+         { id: 'x', value: [ 2, 3, 5] },
+         { id: 't', value: [ 2 ]  },
 ]
 ```
 
 #### Parameters
 
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### files
-
-Take `Object` containing filename et throw content by chunk
-
-Note : files must be under the working directory of the Node.js process.
-
-```json
-[ fi1e1.csv, file2.csv ]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-plugin = basics
-
-[files]
-[CSVParse]
-```
-
-Output:
-
-```json
-[
-(...)
-]
-```
-
-#### Parameters
-
--   `location` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path location to find files (optional, default `.`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### buffers
-
-Takes all `Objects` from a store
-
-```json
-[
-     'AEERRFFF',
-     'DFERGGGV',
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[buffers]
-from = store/13455666/ddd
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: 54, bufferID: 'AEERRFFF' },
-          { year: 2001, dept: 55, bufferID: 'AEERRFFF' },
-          { annee: 2003, bufferID: 'DFERGGGV' },
- ]
-```
-
-#### Parameters
-
--   `from` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the store id
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### maximizing
-
-Take special `Object` like `{id, value}` and replace `value` with the max of `value`s
-
-```json
-[
-  { id: 'toul', value: [1, 2, 3] },
-  { id: 'nancy', value: [2, 3, 4] },
-  { id: 'neufchateau', value: [3, 4, 5] },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[maximizing]
-```
-
-Output:
-
-```json
-[
-   { "id": "toul", "value": 3 },
-   { "id": "nancy", "value": 4 },
-   { "id": "neufchateau", "value": 5 }
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (if not found 1 is the default value) (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -281,14 +131,15 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### groupingByModulo
+### buffers
 
-Take `Object` like `{ id, value }` and reduce all `value`s with the same
-modulo computation in a ansingle object
+Takes all `Objects` from a store
 
 ```json
-[{
-}]
+[
+     'AEERRFFF',
+     'DFERGGGV',
+]
 ```
 
 Script:
@@ -297,34 +148,37 @@ Script:
 [use]
 plugin = analytics
 
-[groupingByModulo]
+[buffers]
+from = store/13455666/ddd
 ```
 
 Output:
 
 ```json
-[
-]
+ [
+          { year: 2000, dept: 54, bufferID: 'AEERRFFF' },
+          { year: 2001, dept: 55, bufferID: 'AEERRFFF' },
+          { annee: 2003, bufferID: 'DFERGGGV' },
+ ]
 ```
 
 #### Parameters
 
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `from` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the store id
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### reducing
+### combine
 
-Take `Object` group value of `{ id, value }` objectpath
+Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
+the internal pipeline must produce a stream of special object (id, value)
 
 ```json
-[{
-         { id: 'x', value: 2 },
-         { id: 't', value: 2 },
-         { id: 'x', value: 3 },
-         { id: 'x', value: 5 },
-}]
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
 ```
 
 Script:
@@ -333,36 +187,55 @@ Script:
 [use]
 plugin = analytics
 
-[reducing]
+[combine]
+path = dept
+file = ./departement.ini
 ```
 
 Output:
 
 ```json
-[
-         { id: 'x', value: [2, 3, 5] },
-         { id: 't', value: [2] },
-]
+ [
+          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
+          { year: 2001, dept: { id: 55, value: 'Meuse' } },
+          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
+ ]
 ```
 
 #### Parameters
 
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
+-   `default` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value if no substitution (otherwise value stay unchanged)
+-   `primer` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Data to send to the external pipeline (optional, default `auto`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `persistent` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The internal database will be reused until it is deleted (optional, default `false`)
+-   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### aggregate
+### count
 
-Aggregate by id and count
+Take `Object` and throw special `Object` like `{id, value}` if key(s) was found
+id is the key, value is equal to 1 (if found)
 
 ```json
-[{
-         { id: 'x', value: 2 },
-         { id: 't', value: 2 },
-         { id: 'x', value: 3 },
-         { id: 'x', value: 5 },
-}]
+[
+ {
+      "a": "nancy",
+      "b": "lucy",
+      "c": "geny",
+  },
+  {
+      "a": "lorem",
+      "b": "loret",
+  },
+  {
+      "a": "fred",
+  }
+]
 ```
 
 Script:
@@ -370,42 +243,77 @@ Script:
 ```ini
 [use]
 plugin = analytics
+
+[count]
+path = a
+path = b
+path = c
 
 [aggregate]
-path = id
+[summing]
 ```
 
 Output:
 
 ```json
-[
-         { id: 'x', value: [ 2, 3, 5] },
-         { id: 't', value: [ 2 ]  },
-]
+[{
+   "id": "a",
+   "value": 3
+},
+{
+   "id": "b",
+   "value": 2
+},
+{
+   "id": "c",
+   "value": 1
+}]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (if not found 1 is the default value) (optional, default `value`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### slice
+### distance
 
-Take `Object` and throw the same object only if it is in the section of the
-stream between start and start + size. stream is numbered from 1
+To compare 2 fields with 2 id and compute a distance
+
+-   for arrays, the distance is calculated according to the number of element in common
 
 ```json
 [{
- { id: 2000, value: 1 },
- { id: 2001, value: 2 },
- { id: 2003, value: 3 },
- { id: 2005, value: 4 },
- { id: 2007, value: 5 },
- { id: 2009, value: 6 },
- { id: 2011, value: 7 },
- { id: 2013, value: 8 },
+           {
+              id_of_a: 1,
+              id_of_b: 2,
+              a: ['x', 'y'],
+              b: ['x', 'z'],
+          },
+          {
+              id_of_a: 1,
+              id_of_b: 3,
+              a: ['x', 'y'],
+              b: ['y', 'z'],
+          },
+          {
+              id_of_a: 1,
+              id_of_b: 4,
+              a: ['x', 'y'],
+              b: ['z'],
+          },
+          {
+              id_of_a: 1,
+              id_of_b: 5,
+              a: ['x', 'y'],
+              b: ['x', 'y', 'z'],
+          },
+          {
+              id_of_a: 1,
+              id_of_b: 6,
+              a: ['x', 'y'],
+              b: ['x', 'y'],
+          },
 }]
 ```
 
@@ -415,22 +323,30 @@ Script:
 [use]
 plugin = analytics
 
-[drop]
+[distance]
+id = id_of_a
+id = id_of_b
+value = a
+value = b
 ```
 
 Output:
 
 ```json
 [
-{ "id": 2001, "value": 2 },
-{ "id": 2003, "value": 3 },
+    { id: [ 1, 2 ], value: 0.5 },
+    { id: [ 1, 3 ], value: 0.5 },
+    { id: [ 1, 4 ], value: 0 },
+    { id: [ 1, 5 ], value: 0.8 },
+    { id: [ 1, 6 ], value: 1 }
+  ]
+
 ]
 ```
 
 #### Parameters
 
--   `start` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** start of the slice (optional, default `0`)
--   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of the slice (optional, default `10`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -476,6 +392,161 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### distribute
+
+Take `Object` like { id, value } and throw a serie of number value
+
+```json
+[
+          { id: 2000, value: 1 },
+          { id: 2001, value: 2 },
+          { id: 2003, value: 3 },
+          { id: 2005, value: 4 },
+          { id: 2007, value: 5 },
+          { id: 2009, value: 6 },
+          { id: 2011, value: 7 },
+          { id: 2013, value: 8 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[distribute]
+```
+
+Output:
+
+```json
+[
+      { "id": 2000, "value": 1 },
+     { "id": 2001, "value": 2 },
+     { "id": 2002, "value": 0 },
+     { "id": 2003, "value": 3 },
+     { "id": 2004, "value": 0 },
+     { "id": 2005, "value": 4 },
+     { "id": 2006, "value": 0 },
+     { "id": 2007, "value": 5 },
+     { "id": 2008, "value": 0 },
+     { "id": 2009, "value": 6 },
+     { "id": 2010, "value": 0 },
+     { "id": 2011, "value": 7 },
+     { "id": 2012, "value": 0 },
+     { "id": 2013, "value": 8 }
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
+-   `step` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** step between each value (optional, default `1`)
+-   `start` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** first value to throw (optional, default `minvalueinthestream`)
+-   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of the distribution (optional, default `(maxvalue-minvalue)inthestream`)
+-   `default` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** default value for missing object (optional, default `0`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### drop
+
+Take `Object` and throw the same object only if there the value of the select field is not equals than a value
+
+```json
+[
+  {
+   "departure": "nancy",
+   "arrival": "paris",
+ },
+ {
+   "departure": "nancy",
+   "arrival": "toul",
+ },
+ {
+   "departure": "paris",
+   "arrival": "londre",
+ }
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[drop]
+```
+
+Output:
+
+```json
+[{
+  "departure": "nancy",
+  "arrival": "paris"
+},
+{
+   "departure": "nancy",
+  "arrival": "toul"
+}]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path of the field to compare (optional, default `"value"`)
+-   `if` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** value to compare (optional, default `""`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### expand
+
+Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
+the internal pipeline receive a special object { id, value } id is the item identifier & value is the item path value
+The internal pipeline can expand value with another
+
+```json
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[expand]
+path = dept
+file = ./departement.ini
+```
+
+Output:
+
+```json
+ [
+          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
+          { year: 2001, dept: { id: 55, value: 'Meuse' } },
+          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
+ ]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
+-   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** How many chunk for sending to the external pipeline (optional, default `1`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `cacheName` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Enable cache, with dedicated name
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### exploding
 
 Take `Object` and take values with [value] path (must be an array)
@@ -518,16 +589,14 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### graph
+### files
 
-Take `Object` and throw a new special object (id, value) for each combination of values
+Take `Object` containing filename et throw content by chunk
+
+Note : files must be under the working directory of the Node.js process.
 
 ```json
-[
- { cities: ['berlin', 'nancy', 'toul'] },
- { cities: ['paris', 'nancy', 'toul']},
- { cities: ['paris', 'berlin', 'toul'] },
-}]
+[ fi1e1.csv, file2.csv ]
 ```
 
 Script:
@@ -535,187 +604,23 @@ Script:
 ```ini
 [use]
 plugin = analytics
+plugin = basics
 
-[graph]
-path = cities
+[files]
+[CSVParse]
 ```
 
 Output:
 
 ```json
 [
-  { "id": [ "berlin", "nancy" ], "value": 1 },
-  { "id": [ "berlin", "toul" ], "value": 2 },
-  { "id": [ "nancy", "toul" ], "value": 2 },
-  { "id": [ "nancy", "paris" ], "value": 1 },
-  { "id": [ "paris", "toul" ], "value": 2 },
-  { "id": [ "berlin", "paris" ], "value": 1 }
+(...)
 ]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### upload
-
-save all objects in a temporary file
-For non Buffer chunks, each object is transformed into a
-string of characters in a raw way (no separator)
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[upload]
-cleanupDelay = 5
-```
-
-Output:
-
-```json
- [
-          { id: '/tmp/31234qdE33334dZE', value:3 },
- ]
-```
-
-#### Parameters
-
--   `extension` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file extension (optional, default `bin`)
--   `prefix` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file prefix (optional, default `upload`)
--   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** TTL in seconds, before cleanup the file (EZS_DELAY) (optional, default `3600`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### pair
-
-Take `Object` object getting some fields with json path, and
-throw all pair of value from two fields
-
-```json
-[
- { departure: ['tokyo', 'nancy'], arrival: 'toul' },
- { departure: ['paris', 'nancy'], arrival: 'toul' },
- { departure: ['london', 'berlin'], arrival: 'toul' },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[pair]
-path = departure
-path = arrival
-```
-
-Output:
-
-```json
-[
- { "id": [ "tokyo", "toul" ], "value": 1 },
-{ "id": [ "nancy", "toul" ], "value": 1 },
-{ "id": [ "paris", "toul" ], "value": 1 },
- { "id": [ "nancy", "toul" ], "value": 1 },
- { "id": [ "london", "toul" ], "value": 1 },
- { "id": [ "berlin", "toul" ], "value": 1 }
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### merging
-
-Take special `Object` like `{id, value}` and replace `value` with the merge of `value`s
-
-```json
-[{
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[merging]
-```
-
-Output:
-
-```json
-[
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### summing
-
-Take special `Object` like `{id, value}` and replace `value` with the sum of
-`value`s
-
-```json
-[
- { "id": "A", "value": [1, 1, 1] },
- { "id": "B", "value": [1] },
- { "id": "C", "value": [1, 1, 1, 1] },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[summing]
-```
-
-Output:
-
-```json
-[{
-  "id": "A", "value": 3
-},
-{
-   "id": "B",
-   "value": 1
-},
-{
-   "id": "C",
-  "value": 4
-}]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+-   `location` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path location to find files (optional, default `.`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -765,21 +670,16 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### value
+### graph
 
-Take `Object` object and getting the value field
+Take `Object` and throw a new special object (id, value) for each combination of values
 
 ```json
 [
- { id: 2000, value: 1 },
- { id: 2001, value: 2 },
- { id: 2003, value: 3 },
- { id: 2005, value: 4 },
- { id: 2007, value: 5 },
- { id: 2009, value: 6 },
- { id: 2011, value: 7 },
- { id: 2013, value: 8 },
-]
+ { cities: ['berlin', 'nancy', 'toul'] },
+ { cities: ['paris', 'nancy', 'toul']},
+ { cities: ['paris', 'berlin', 'toul'] },
+}]
 ```
 
 Script:
@@ -788,28 +688,26 @@ Script:
 [use]
 plugin = analytics
 
-[value]
-path = id
+[graph]
+path = cities
 ```
 
 Output:
 
 ```json
 [
-2000,
-2001,
-2003,
-2005,
-2007,
-2009,
-2011,
-2013
+  { "id": [ "berlin", "nancy" ], "value": 1 },
+  { "id": [ "berlin", "toul" ], "value": 2 },
+  { "id": [ "nancy", "toul" ], "value": 2 },
+  { "id": [ "nancy", "paris" ], "value": 1 },
+  { "id": [ "paris", "toul" ], "value": 2 },
+  { "id": [ "berlin", "paris" ], "value": 1 }
 ]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the pah of the value field (optional, default `value`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -862,21 +760,21 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### pluck
+### groupingByEquality
 
-Take `Object` object getting value of fields (with json `path`) and throws an
-object for each value
+Take `Object` like `{ id, value }` and reduce all values with the same `id`
+in a single object
 
 ```json
 [
- { city: 'tokyo', year: 2000, count: 1 },
- { city: 'paris', year: 2001, count: 2 },
- { city: 'london', year: 2003, count: 3 },
- { city: 'nancy', year: 2005, count: 4 },
- { city: 'berlin', year: 2007, count: 5 },
- { city: 'madrid', year: 2009, count: 6 },
- { city: 'stockholm', year: 2011, count: 7 },
- { city: 'bruxelles', year: 2013, count: 8 },
+   { "id": "lorem", "value": 1 },
+   { "id": "Lorem", "value": 1 },
+   { "id": "loren", "value": 1 },
+   { "id": "korem", "value": 1 },
+   { "id": "olrem", "value": 1 },
+   { "id": "toto", "value": 1 },
+   { "id": "titi", "value": 1 },
+   { "id": "lorem", "value": 1 }
 ]
 ```
 
@@ -886,78 +784,29 @@ Script:
 [use]
 plugin = analytics
 
-[pluck]
-path = year
+[groupingByEquality]
+
+[summing]
 ```
 
 Output:
 
 ```json
 [
-{ "id": "year", "value": 2000 },
-{ "id": "year", "value": 2001 },
-{ "id": "year", "value": 2003 },
-{ "id": "year", "value": 2005 },
-{ "id": "year", "value": 2007 },
-{ "id": "year", "value": 2009 },
-{ "id": "year", "value": 2011 },
-{ "id": "year", "value": 2013 }
+  { "id": [ "lorem" ], "value": 2 },
+  { "id": [ "Lorem" ], "value": 1 },
+  { "id": [ "loren" ], "value": 1 },
+  { "id": [ "korem" ], "value": 1 },
+  { "id": [ "olrem" ], "value": 1 },
+  { "id": [ "toto" ], "value": 1 },
+  { "id": [ "titi" ], "value": 1 }
 ]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use form group by (optional, default `id`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### drop
-
-Take `Object` and throw the same object only if there the value of the select field is not equals than a value
-
-```json
-[
-  {
-   "departure": "nancy",
-   "arrival": "paris",
- },
- {
-   "departure": "nancy",
-   "arrival": "toul",
- },
- {
-   "departure": "paris",
-   "arrival": "londre",
- }
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[drop]
-```
-
-Output:
-
-```json
-[{
-  "departure": "nancy",
-  "arrival": "paris"
-},
-{
-   "departure": "nancy",
-  "arrival": "toul"
-}]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path of the field to compare (optional, default `"value"`)
--   `if` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** value to compare (optional, default `""`)
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1055,6 +904,39 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### groupingByModulo
+
+Take `Object` like `{ id, value }` and reduce all `value`s with the same
+modulo computation in a ansingle object
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[groupingByModulo]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### keys
 
 Take `Object` and throws all its keys
@@ -1105,140 +987,6 @@ Output:
 #### Parameters
 
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### groupingByEquality
-
-Take `Object` like `{ id, value }` and reduce all values with the same `id`
-in a single object
-
-```json
-[
-   { "id": "lorem", "value": 1 },
-   { "id": "Lorem", "value": 1 },
-   { "id": "loren", "value": 1 },
-   { "id": "korem", "value": 1 },
-   { "id": "olrem", "value": 1 },
-   { "id": "toto", "value": 1 },
-   { "id": "titi", "value": 1 },
-   { "id": "lorem", "value": 1 }
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[groupingByEquality]
-
-[summing]
-```
-
-Output:
-
-```json
-[
-  { "id": [ "lorem" ], "value": 2 },
-  { "id": [ "Lorem" ], "value": 1 },
-  { "id": [ "loren" ], "value": 1 },
-  { "id": [ "korem" ], "value": 1 },
-  { "id": [ "olrem" ], "value": 1 },
-  { "id": [ "toto" ], "value": 1 },
-  { "id": [ "titi" ], "value": 1 }
-]
-```
-
-#### Parameters
-
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### tune
-
-Take all `Object` and sort them with selected field
-
-```json
-[{
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[tune]
-```
-
-Output:
-
-```json
-[
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for the sort key (optional, default `id`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### multiply
-
-Take `Object` and throw the same object only if there the value of the select field is equals than a value
-Input file:
-
-```json
-[{
-   a: 1,
-   b: 2,
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[multiply]
-path = factor
-value = X
-value = Y
-value = Z
-```
-
-Output:
-
-```json
-[{
-   a: 1,
-   b: 2,
-   factor: X
-},
-{
-   a: 1,
-   b: 2,
-   factor: Y
-},
-{
-   a: 1,
-   b: 2,
-   factor: Z
-},
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path of the field to add (optional, default `"factor"`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** value(s) to set factor field (optional, default `""`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1300,25 +1048,15 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### count
+### maximizing
 
-Take `Object` and throw special `Object` like `{id, value}` if key(s) was found
-id is the key, value is equal to 1 (if found)
+Take special `Object` like `{id, value}` and replace `value` with the max of `value`s
 
 ```json
 [
- {
-      "a": "nancy",
-      "b": "lucy",
-      "c": "geny",
-  },
-  {
-      "a": "lorem",
-      "b": "loret",
-  },
-  {
-      "a": "fred",
-  }
+  { id: 'toul', value: [1, 2, 3] },
+  { id: 'nancy', value: [2, 3, 4] },
+  { id: 'neufchateau', value: [3, 4, 5] },
 ]
 ```
 
@@ -1328,30 +1066,225 @@ Script:
 [use]
 plugin = analytics
 
-[count]
-path = a
-path = b
-path = c
+[maximizing]
+```
 
-[aggregate]
-[summing]
+Output:
+
+```json
+[
+   { "id": "toul", "value": 3 },
+   { "id": "nancy", "value": 4 },
+   { "id": "neufchateau", "value": 5 }
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### merging
+
+Take special `Object` like `{id, value}` and replace `value` with the merge of `value`s
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[merging]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### minimizing
+
+Take special `Object` like `{id, value}` and replace `value` with the min of
+`value`s
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[drop]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### multiply
+
+Take `Object` and throw the same object only if there the value of the select field is equals than a value
+Input file:
+
+```json
+[{
+   a: 1,
+   b: 2,
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[multiply]
+path = factor
+value = X
+value = Y
+value = Z
 ```
 
 Output:
 
 ```json
 [{
-   "id": "a",
-   "value": 3
+   a: 1,
+   b: 2,
+   factor: X
 },
 {
-   "id": "b",
-   "value": 2
+   a: 1,
+   b: 2,
+   factor: Y
 },
 {
-   "id": "c",
-   "value": 1
-}]
+   a: 1,
+   b: 2,
+   factor: Z
+},
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path of the field to add (optional, default `"factor"`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** value(s) to set factor field (optional, default `""`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### output
+
+Format the output with data a meta
+
+#### Parameters
+
+-   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent or not (optional, default `false`)
+-   `meta` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>?** fields to be considered as metadata
+                                      object
+
+#### Examples
+
+Input
+
+
+```javascript
+[
+     { _id: 1, value: 2, total: 2 },
+     { _id: 2, value: 4, total: 2 }
+]
+```
+
+Script
+
+
+```javascript
+.pipe(ezs('output', { meta: 'total' }))
+```
+
+Output
+
+
+```javascript
+{
+    data: [
+        { _id: 1, value: 2 },
+        { _id: 2, value: 4 }
+    ],
+    meta: {
+        total: 2
+    }
+}
+```
+
+Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### pair
+
+Take `Object` object getting some fields with json path, and
+throw all pair of value from two fields
+
+```json
+[
+ { departure: ['tokyo', 'nancy'], arrival: 'toul' },
+ { departure: ['paris', 'nancy'], arrival: 'toul' },
+ { departure: ['london', 'berlin'], arrival: 'toul' },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[pair]
+path = departure
+path = arrival
+```
+
+Output:
+
+```json
+[
+ { "id": [ "tokyo", "toul" ], "value": 1 },
+{ "id": [ "nancy", "toul" ], "value": 1 },
+{ "id": [ "paris", "toul" ], "value": 1 },
+ { "id": [ "nancy", "toul" ], "value": 1 },
+ { "id": [ "london", "toul" ], "value": 1 },
+ { "id": [ "berlin", "toul" ], "value": 1 }
+]
 ```
 
 #### Parameters
@@ -1360,20 +1293,21 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### distribute
+### pluck
 
-Take `Object` like { id, value } and throw a serie of number value
+Take `Object` object getting value of fields (with json `path`) and throws an
+object for each value
 
 ```json
 [
-          { id: 2000, value: 1 },
-          { id: 2001, value: 2 },
-          { id: 2003, value: 3 },
-          { id: 2005, value: 4 },
-          { id: 2007, value: 5 },
-          { id: 2009, value: 6 },
-          { id: 2011, value: 7 },
-          { id: 2013, value: 8 },
+ { city: 'tokyo', year: 2000, count: 1 },
+ { city: 'paris', year: 2001, count: 2 },
+ { city: 'london', year: 2003, count: 3 },
+ { city: 'nancy', year: 2005, count: 4 },
+ { city: 'berlin', year: 2007, count: 5 },
+ { city: 'madrid', year: 2009, count: 6 },
+ { city: 'stockholm', year: 2011, count: 7 },
+ { city: 'bruxelles', year: 2013, count: 8 },
 ]
 ```
 
@@ -1383,55 +1317,41 @@ Script:
 [use]
 plugin = analytics
 
-[distribute]
+[pluck]
+path = year
 ```
 
 Output:
 
 ```json
 [
-      { "id": 2000, "value": 1 },
-     { "id": 2001, "value": 2 },
-     { "id": 2002, "value": 0 },
-     { "id": 2003, "value": 3 },
-     { "id": 2004, "value": 0 },
-     { "id": 2005, "value": 4 },
-     { "id": 2006, "value": 0 },
-     { "id": 2007, "value": 5 },
-     { "id": 2008, "value": 0 },
-     { "id": 2009, "value": 6 },
-     { "id": 2010, "value": 0 },
-     { "id": 2011, "value": 7 },
-     { "id": 2012, "value": 0 },
-     { "id": 2013, "value": 8 }
+{ "id": "year", "value": 2000 },
+{ "id": "year", "value": 2001 },
+{ "id": "year", "value": 2003 },
+{ "id": "year", "value": 2005 },
+{ "id": "year", "value": 2007 },
+{ "id": "year", "value": 2009 },
+{ "id": "year", "value": 2011 },
+{ "id": "year", "value": 2013 }
 ]
 ```
 
 #### Parameters
 
--   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `"id"`)
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `"value"`)
--   `step` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** step between each value (optional, default `1`)
--   `start` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** first value to throw (optional, default `minvalueinthestream`)
--   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of the distribution (optional, default `(maxvalue-minvalue)inthestream`)
--   `default` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** default value for missing object (optional, default `0`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use form group by (optional, default `id`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### sort
+### reducing
 
-Take all `Object` and sort them with dedicated key
+Take `Object` group value of `{ id, value }` objectpath
 
 ```json
 [{
- { id: 2000, value: 1 },
- { id: 2001, value: 2 },
- { id: 2003, value: 3 },
- { id: 2005, value: 4 },
- { id: 2007, value: 5 },
- { id: 2009, value: 6 },
- { id: 2011, value: 7 },
- { id: 2013, value: 8 },
+         { id: 'x', value: 2 },
+         { id: 't', value: 2 },
+         { id: 'x', value: 3 },
+         { id: 'x', value: 5 },
 }]
 ```
 
@@ -1441,199 +1361,22 @@ Script:
 [use]
 plugin = analytics
 
-[sort]
-path = value
-reverse = true
+[reducing]
 ```
 
 Output:
 
 ```json
 [
-{ "id": 2013, "value": 8 },
-{ "id": 2011, "value": 7 },
-{ "id": 2009, "value": 6 },
-{ "id": 2007, "value": 5 },
-{ "id": 2005, "value": 4 },
-{ "id": 2003, "value": 3 },
-{ "id": 2001, "value": 2 },
-{ "id": 2000, "value": 1 }
+         { id: 'x', value: [2, 3, 5] },
+         { id: 't', value: [2] },
 ]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
--   `reverse` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** reverser order (optional, default `false`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### combine
-
-Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
-the internal pipeline must produce a stream of special object (id, value)
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[combine]
-path = dept
-file = ./departement.ini
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
-          { year: 2001, dept: { id: 55, value: 'Meuse' } },
-          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
- ]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
--   `default` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value if no substitution (otherwise value stay unchanged)
--   `primer` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Data to send to the external pipeline (optional, default `auto`)
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `persistent` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The internal database will be reused until it is deleted (optional, default `false`)
--   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### distance
-
-To compare 2 fields with 2 id and compute a distance
-
--   for arrays, the distance is calculated according to the number of element in common
-
-```json
-[{
-           {
-              id_of_a: 1,
-              id_of_b: 2,
-              a: ['x', 'y'],
-              b: ['x', 'z'],
-          },
-          {
-              id_of_a: 1,
-              id_of_b: 3,
-              a: ['x', 'y'],
-              b: ['y', 'z'],
-          },
-          {
-              id_of_a: 1,
-              id_of_b: 4,
-              a: ['x', 'y'],
-              b: ['z'],
-          },
-          {
-              id_of_a: 1,
-              id_of_b: 5,
-              a: ['x', 'y'],
-              b: ['x', 'y', 'z'],
-          },
-          {
-              id_of_a: 1,
-              id_of_b: 6,
-              a: ['x', 'y'],
-              b: ['x', 'y'],
-          },
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[distance]
-id = id_of_a
-id = id_of_b
-value = a
-value = b
-```
-
-Output:
-
-```json
-[
-    { id: [ 1, 2 ], value: 0.5 },
-    { id: [ 1, 3 ], value: 0.5 },
-    { id: [ 1, 4 ], value: 0 },
-    { id: [ 1, 5 ], value: 0.8 },
-    { id: [ 1, 6 ], value: 1 }
-  ]
-
-]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `value`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### expand
-
-Takes an `Object` and substitute a field with the corresponding value found in a external pipeline
-the internal pipeline receive a special object { id, value } id is the item identifier & value is the item path value
-The internal pipeline can expand value with another
-
-```json
-[
-          { year: 2000, dept: 54 },
-          { year: 2001, dept: 55 },
-          { year: 2003, dept: 54 },
-]
-```
-
-Script:
-
-```ini
-[use]
-plugin = analytics
-
-[expand]
-path = dept
-file = ./departement.ini
-```
-
-Output:
-
-```json
- [
-          { year: 2000, dept: { id: 54, value: 'Meurthe et moselle' } },
-          { year: 2001, dept: { id: 55, value: 'Meuse' } },
-          { year: 2003, dept: { id: 54, value: 'Meurthe et moselle' } },
- ]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the path to substitute
--   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** How many chunk for sending to the external pipeline (optional, default `1`)
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `cacheName` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Enable cache, with dedicated name
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1716,6 +1459,99 @@ Output:
 
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path (optional, default `value`)
 -   `aggregate` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** aggregate all values for all paths (or not) (optional, default `true`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### slice
+
+Take `Object` and throw the same object only if it is in the section of the
+stream between start and start + size. stream is numbered from 1
+
+```json
+[{
+ { id: 2000, value: 1 },
+ { id: 2001, value: 2 },
+ { id: 2003, value: 3 },
+ { id: 2005, value: 4 },
+ { id: 2007, value: 5 },
+ { id: 2009, value: 6 },
+ { id: 2011, value: 7 },
+ { id: 2013, value: 8 },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[drop]
+```
+
+Output:
+
+```json
+[
+{ "id": 2001, "value": 2 },
+{ "id": 2003, "value": 3 },
+]
+```
+
+#### Parameters
+
+-   `start` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** start of the slice (optional, default `0`)
+-   `size` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of the slice (optional, default `10`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### sort
+
+Take all `Object` and sort them with dedicated key
+
+```json
+[{
+ { id: 2000, value: 1 },
+ { id: 2001, value: 2 },
+ { id: 2003, value: 3 },
+ { id: 2005, value: 4 },
+ { id: 2007, value: 5 },
+ { id: 2009, value: 6 },
+ { id: 2011, value: 7 },
+ { id: 2013, value: 8 },
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[sort]
+path = value
+reverse = true
+```
+
+Output:
+
+```json
+[
+{ "id": 2013, "value": 8 },
+{ "id": 2011, "value": 7 },
+{ "id": 2009, "value": 6 },
+{ "id": 2007, "value": 5 },
+{ "id": 2005, "value": 4 },
+{ "id": 2003, "value": 3 },
+{ "id": 2001, "value": 2 },
+{ "id": 2000, "value": 1 }
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `reverse` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** reverser order (optional, default `false`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -1827,5 +1663,169 @@ Output
 }]
 ```
 ````
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### summing
+
+Take special `Object` like `{id, value}` and replace `value` with the sum of
+`value`s
+
+```json
+[
+ { "id": "A", "value": [1, 1, 1] },
+ { "id": "B", "value": [1] },
+ { "id": "C", "value": [1, 1, 1, 1] },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[summing]
+```
+
+Output:
+
+```json
+[{
+  "id": "A", "value": 3
+},
+{
+   "id": "B",
+   "value": 1
+},
+{
+   "id": "C",
+  "value": 4
+}]
+```
+
+#### Parameters
+
+-   `id` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for id (optional, default `id`)
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for value (optional, default `value`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### tune
+
+Take all `Object` and sort them with selected field
+
+```json
+[{
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[tune]
+```
+
+Output:
+
+```json
+[
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to use for the sort key (optional, default `id`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### upload
+
+save all objects in a temporary file
+For non Buffer chunks, each object is transformed into a
+string of characters in a raw way (no separator)
+
+```json
+[
+          { year: 2000, dept: 54 },
+          { year: 2001, dept: 55 },
+          { year: 2003, dept: 54 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[upload]
+cleanupDelay = 5
+```
+
+Output:
+
+```json
+ [
+          { id: '/tmp/31234qdE33334dZE', value:3 },
+ ]
+```
+
+#### Parameters
+
+-   `extension` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file extension (optional, default `bin`)
+-   `prefix` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** set the file prefix (optional, default `upload`)
+-   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** TTL in seconds, before cleanup the file (EZS_DELAY) (optional, default `3600`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### value
+
+Take `Object` object and getting the value field
+
+```json
+[
+ { id: 2000, value: 1 },
+ { id: 2001, value: 2 },
+ { id: 2003, value: 3 },
+ { id: 2005, value: 4 },
+ { id: 2007, value: 5 },
+ { id: 2009, value: 6 },
+ { id: 2011, value: 7 },
+ { id: 2013, value: 8 },
+]
+```
+
+Script:
+
+```ini
+[use]
+plugin = analytics
+
+[value]
+path = id
+```
+
+Output:
+
+```json
+[
+2000,
+2001,
+2003,
+2005,
+2007,
+2009,
+2011,
+2013
+]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the pah of the value field (optional, default `value`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -33,7 +33,7 @@
   },
   "main": "./lib/index.js",
   "scripts": {
-    "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-analytics.md --section=usage && cp ../../docs/plugin-analytics.md ./README.md",
+    "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-analytics.md --section=usage && cp ../../docs/plugin-analytics.md ./README.md",
     "lint": "eslint --ext=.js ./test/*.js ./src/*.js",
     "build": "babel --root-mode upward src --out-dir lib",
     "prepublish": "npm run build",

--- a/packages/ark/package.json
+++ b/packages/ark/package.json
@@ -27,7 +27,7 @@
   },
   "main": "./lib/index.js",
   "scripts": {
-    "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-ark.md --section=usage  && cp ../../docs/plugin-ark.md ./README.md",
+    "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-ark.md --section=usage  && cp ../../docs/plugin-ark.md ./README.md",
     "lint": "eslint --ext=.js ./test/*.js ./src/*.js",
     "build": "babel --root-mode upward src --out-dir lib",
     "prepublish": "npm run build",

--- a/packages/conditor/README.md
+++ b/packages/conditor/README.md
@@ -52,9 +52,57 @@ Sachant qu'on appauvrit (casse, accents, tiret, apostrophe) tous les champs.
 
 #### Table of Contents
 
+-   [affAlign](#affalign)
 -   [compareRnsr](#comparernsr)
 -   [conditorScroll](#conditorscroll)
--   [affAlign](#affalign)
+
+### affAlign
+
+Find the RNSR identifiers in the authors affiliation addresses.
+
+Input file:
+
+```json
+[{
+     "xPublicationDate": ["2012-01-01", "2012-01-01"],
+     "authors": [{
+         "affiliations": [{
+             "address": "GDR 2989 Université Versailles Saint-Quentin-en-Yvelines, 63009"
+         }]
+     }]
+}]
+```
+
+Script:
+
+```ini
+[use]
+plugin = basics
+plugin = conditor
+
+[JSONParse]
+[affAlign]
+[JSONString]
+indent = true
+```
+
+Output:
+
+```json
+[{
+     "xPublicationDate": ["2012-01-01", "2012-01-01"],
+     "authors": [{
+         "affiliations": [{
+             "address": "GDR 2989 Université Versailles Saint-Quentin-en-Yvelines, 63009",
+             "conditorRnsr": ["200619958X"]
+         }]
+     }]
+}]
+```
+
+#### Parameters
+
+-   `year` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Year of the RNSR to use instead of the last one
 
 ### compareRnsr
 
@@ -140,51 +188,3 @@ Output
 ```
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
-
-### affAlign
-
-Find the RNSR identifiers in the authors affiliation addresses.
-
-Input file:
-
-```json
-[{
-     "xPublicationDate": ["2012-01-01", "2012-01-01"],
-     "authors": [{
-         "affiliations": [{
-             "address": "GDR 2989 Université Versailles Saint-Quentin-en-Yvelines, 63009"
-         }]
-     }]
-}]
-```
-
-Script:
-
-```ini
-[use]
-plugin = basics
-plugin = conditor
-
-[JSONParse]
-[affAlign]
-[JSONString]
-indent = true
-```
-
-Output:
-
-```json
-[{
-     "xPublicationDate": ["2012-01-01", "2012-01-01"],
-     "authors": [{
-         "affiliations": [{
-             "address": "GDR 2989 Université Versailles Saint-Quentin-en-Yvelines, 63009",
-             "conditorRnsr": ["200619958X"]
-         }]
-     }]
-}]
-```
-
-#### Parameters
-
--   `year` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Year of the RNSR to use instead of the last one

--- a/packages/conditor/package.json
+++ b/packages/conditor/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "babel src --out-dir lib",
-    "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-conditor.md --section=usage && cp ../../docs/plugin-conditor.md ./README.md",
+    "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-conditor.md --section=usage && cp ../../docs/plugin-conditor.md ./README.md",
     "lint": "eslint --ext=.js ./test/*.js ./src/*.js ./bin/*.js",
     "prepublish": "npm run build",
     "pretest": "npm run build",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,213 +14,38 @@ npm install @ezs/core
 
 #### Table of Contents
 
--   [pack](#pack)
--   [unpack](#unpack)
--   [tracer](#tracer)
--   [env](#env)
--   [spawn](#spawn)
+-   [assign](#assign)
+-   [concat](#concat)
 -   [debug](#debug)
 -   [delegate](#delegate)
 -   [dispatch](#dispatch)
--   [metrics](#metrics)
--   [swing](#swing)
--   [parallel](#parallel)
--   [time](#time)
--   [transit](#transit)
--   [concat](#concat)
--   [ungroup](#ungroup)
--   [group](#group)
--   [shift](#shift)
+-   [dump](#dump)
+-   [env](#env)
 -   [exchange](#exchange)
 -   [extract](#extract)
--   [keep](#keep)
+-   [group](#group)
 -   [ignore](#ignore)
--   [dump](#dump)
+-   [keep](#keep)
+-   [metrics](#metrics)
+-   [pack](#pack)
+-   [parallel](#parallel)
 -   [remove](#remove)
--   [truncate](#truncate)
--   [shuffle](#shuffle)
--   [validate](#validate)
 -   [replace](#replace)
--   [assign](#assign)
-
-### pack
-
-Take all `Object`, throw encoded `String`
-
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### unpack
-
-Take `String` and throw `Object` builded by JSON.parse on each line
-
-Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### tracer
-
-Take `Object`, print a character and throw the same object.
-Useful to see the progress in the stream.
-
-#### Parameters
-
--   `print` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at each object (optional, default `.`)
--   `last` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at last call (optional, default `.`)
--   `first` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at first call (optional, default `.`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### env
-
-Take `Object` and send the same object but in the meantime,
-it is possible to  add new environment field with the first
-Object of the feed
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the new field
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value of the new field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### spawn
-
-Take `Object` and delegate processing to an external pipeline, throw each chunk from the result
-Note : works like [delegate], but each chunk use its own external pipeline
-
-#### Parameters
-
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### debug
-
-Take `Object` , print it and throw the same object
-
-#### Parameters
-
--   `level` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** console level : log or error (optional, default `log`)
--   `text` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** text before the dump (optional, default `valueOf`)
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to print
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### delegate
-
-Takes an `Object` delegate processing to an external pipeline
-Note : works like [spawn], but each chunk share the same external pipeline
-
-#### Parameters
-
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### dispatch
-
-Takes an `Object` dispatch processing to an external pipeline on one or more servers
-
-#### Parameters
-
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### metrics
-
-Take `Object` and throw the same `Object`
-But in print some Prometheus metrics
-
-#### Parameters
-
--   `stage` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Stage name (optional, default `default`)
--   `bucket` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Bucket name (script name) (optional, default `unknow`)
--   `frequency` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** number of chunk between two metrics computation (optional, default `10`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### swing
-
-Takes an `Object` delegate processing to an external pipeline
-under specifics conditions
-Note : works like [spawn], but each chunk share the same external pipeline
-
-#### Parameters
-
--   `test` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** if test is true
--   `reverse` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reverse the test (optional, default `false`)
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### parallel
-
-Takes an `Object` delegate processing to X internal pipelines
-
-#### Parameters
-
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### time
-
-Measure the execution time of a script, on each chunk on input.
-
-#### Parameters
-
--   `script` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
-
-#### Examples
-
-Input
-
-
-```javascript
-[1]
-```
-
-Program
-
-
-```javascript
-const script = `
-[transit]
-`;
-from([1])
-    .pipe(ezs('time', { script }))
-```
-
-Output
-
-
-```javascript
-[{
-  data: 1,
-  time: 15 // milliseconds
-}]
-```
-
-Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### transit
-
-Take `Object` and throw the same object
+-   [shift](#shift)
+-   [shuffle](#shuffle)
+-   [spawn](#spawn)
+-   [swing](#swing)
+-   [time](#time)
+-   [tracer](#tracer)
+-   [transit](#transit)
+-   [truncate](#truncate)
+-   [ungroup](#ungroup)
+-   [unpack](#unpack)
+-   [validate](#validate)
+
+### assign
+
+Take `Object` and add new field
 Input file:
 
 ```json
@@ -229,13 +54,24 @@ Input file:
 },
 {
    a: 2,
+},
+{
+   a: 3,
+},
+{
+   a: 4,
+},
+{
+   a: 5,
 }]
 ```
 
 Script:
 
 ```ini
-[transit]
+[assign]
+path = b.c
+value = 'X'
 ```
 
 Output:
@@ -243,11 +79,30 @@ Output:
 ```json
 [{
    a: 1,
+   b: { c: "X" },
 },
 {
    a: 2,
+   b: { c: "X" },
+},
+{
+   a: 3,
+   b: { c: "X" },
+},
+{
+   a: 4,
+   b: { c: "X" },
+},
+{
+   a: 5,
+   b: { c: "X" },
 }]
 ```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the new field
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value of the new field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -288,120 +143,103 @@ Output:
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
-### ungroup
+### debug
 
--   **See: group
-    **
+Take `Object` , print it and throw the same object
 
-Take all `chunk`s, and throw one item for every chunk
+#### Parameters
+
+-   `level` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** console level : log or error (optional, default `log`)
+-   `text` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** text before the dump (optional, default `valueOf`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to print
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### delegate
+
+Takes an `Object` delegate processing to an external pipeline
+Note : works like [spawn], but each chunk share the same external pipeline
+
+#### Parameters
+
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### dispatch
+
+Takes an `Object` dispatch processing to an external pipeline on one or more servers
+
+#### Parameters
+
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### dump
+
+Take all `Object` and generete a JSON array
 
 ```json
 [
-     [ 'a', 'b', 'c' ],
-     [ 'd', 'e', 'f' ],
-     [ 'g', 'h' ],
+    { a: 1 },
+    { a: 2 },
+    { a: 3 },
+    { a: 4 },
+    { a: 5 }
 ]
 ```
 
 Script:
 
 ```ini
-[ungroup]
+[dump]
+indent = true
 ```
 
 Output:
 
 ```json
-[
-     'a',
-     'b',
-     'c',
-     'd',
-     'e',
-     'f',
-     'g',
-     'h',
-]
-```
-
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### group
-
-Take all `chunk`s, and throw one array of chunks
-
-```json
-[
-     'a',
-     'b',
-     'c',
-     'd',
-     'e',
-     'f',
-     'g',
-     'h',
-]
-```
-
-Script:
-
-```ini
-[group]
-length = 3
-```
-
-Output:
-
-```json
-[
-     [ 'a', 'b', 'c' ],
-     [ 'd', 'e', 'f' ],
-     [ 'g', 'h' ],
+ [{
+    "a": 1
+   },
+   {
+    "a": 2
+   },
+   {
+    "a": 3
+   },
+   {
+    "a": 4
+   },
+   {
+    "a": 5
+   }
 ]
 ```
 
 #### Parameters
 
--   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Size of each partition
+-   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent JSON (optional, default `false`)
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
-### shift
+### env
 
-Return the first `Object` and close the feed
-Input file:
+Take `Object` and send the same object but in the meantime,
+it is possible to  add new environment field with the first
+Object of the feed
 
-```json
-[{
-   a: 1,
-},
-{
-   a: 2,
-},
-{
-   a: 3,
-},
-{
-   a: 4,
-},
-{
-   a: 5,
-}]
-```
+#### Parameters
 
-Script:
-
-```ini
-[shift]
-```
-
-Output:
-
-```json
-[{
-   a: 1,
-}]
-```
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the new field
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value of the new field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -492,50 +330,45 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### keep
+### group
 
-Take `Object` and throw the same object but keep only specific fields
-Input file:
+Take all `chunk`s, and throw one array of chunks
 
 ```json
-[{
-   a: 'abcdefg',
-   b: '1234567',
-   c: 'XXXXXXX',
-},
-{
-   a: 'abcdefg',
-   b: '1234567',
-   c: 'XXXXXXX',
-}]
+[
+     'a',
+     'b',
+     'c',
+     'd',
+     'e',
+     'f',
+     'g',
+     'h',
+]
 ```
 
 Script:
 
 ```ini
-[keep]
-path = a
-path = b
+[group]
+length = 3
 ```
 
 Output:
 
 ```json
-[{
-   a: 'abcdefg',
-   b: '1234567',
-},
-{
-   a: 'abcdefg',
-   b: '1234567',
-}]
+[
+     [ 'a', 'b', 'c' ],
+     [ 'd', 'e', 'f' ],
+     [ 'g', 'h' ],
+]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to keep
+-   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Size of each partition
 
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ### ignore
 
@@ -584,53 +417,82 @@ Output:
 
 Returns **any** 
 
-### dump
+### keep
 
-Take all `Object` and generete a JSON array
+Take `Object` and throw the same object but keep only specific fields
+Input file:
 
 ```json
-[
-    { a: 1 },
-    { a: 2 },
-    { a: 3 },
-    { a: 4 },
-    { a: 5 }
-]
+[{
+   a: 'abcdefg',
+   b: '1234567',
+   c: 'XXXXXXX',
+},
+{
+   a: 'abcdefg',
+   b: '1234567',
+   c: 'XXXXXXX',
+}]
 ```
 
 Script:
 
 ```ini
-[dump]
-indent = true
+[keep]
+path = a
+path = b
 ```
 
 Output:
 
 ```json
- [{
-    "a": 1
-   },
-   {
-    "a": 2
-   },
-   {
-    "a": 3
-   },
-   {
-    "a": 4
-   },
-   {
-    "a": 5
-   }
-]
+[{
+   a: 'abcdefg',
+   b: '1234567',
+},
+{
+   a: 'abcdefg',
+   b: '1234567',
+}]
 ```
 
 #### Parameters
 
--   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent JSON (optional, default `false`)
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to keep
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### metrics
+
+Take `Object` and throw the same `Object`
+But in print some Prometheus metrics
+
+#### Parameters
+
+-   `stage` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Stage name (optional, default `default`)
+-   `bucket` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Bucket name (script name) (optional, default `unknow`)
+-   `frequency` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** number of chunk between two metrics computation (optional, default `10`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### pack
+
+Take all `Object`, throw encoded `String`
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### parallel
+
+Takes an `Object` delegate processing to X internal pipelines
+
+#### Parameters
+
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### remove
 
@@ -679,156 +541,6 @@ Output:
 
 -   `test` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** if test is true
 -   `reverse` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reverse the test (optional, default `false`)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### truncate
-
-Takes all the chunks, and closes the feed when the total length is equal to the parameter
-Input file:
-
-```json
-[{
-   a: 1,
-},
-{
-   a: 2,
-},
-{
-   a: 3,
-},
-{
-   a: 4,
-},
-{
-   a: 5,
-}]
-```
-
-Script:
-
-```ini
-[truncate]
-length = 3
-```
-
-Output:
-
-```json
-[{
-   a: 1,
-},
-{
-   a: 2,
-},
-{
-   a: 3,
-}]
-```
-
-#### Parameters
-
--   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Length of the feed
-
-Returns **any** 
-
-### shuffle
-
-Take `Object`, shuffle data of the whole object or only some fields specified by path
-Input file:
-
-```json
-[{
-   a: 'abcdefg',
-   b: '1234567',
-},
-{
-   a: 'abcdefg',
-   b: '1234567',
-}]
-```
-
-Script:
-
-```ini
-[shuffle]
-path = a
-```
-
-Output:
-
-```json
-[{
-   a: 'cadbefg',
-   b: '1234567',
-},
-{
-   a: 'dcaegbf',
-   b: '1234567',
-}]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to shuffle
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### validate
-
--   **See: laravel validator rules
-    **
--   **See: <https://github.com/skaterdav85/validatorjs#readme>
-    **
-
-From a `Object`, throw the same object if all rules pass
-
-Input file:
-
-```json
-[{
-   a: 1,
-   b: 'titi',
-},
-{
-   a: 2,
-   b: 'toto',
-},
-{
-   a: false,
-},
-]
-```
-
-Script:
-
-```ini
-[validate]
-path = a
-rule = required|number
-
-path = a
-rule = required|string
-```
-
-Output:
-
-```json
-[{
-   a: 1,
-   b: 'titi',
-},
-{
-   a: 2,
-   b: 'toto',
-},
-}]
-```
-
-#### Parameters
-
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the field
--   `rule` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** rule to validate the field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -890,9 +602,9 @@ Output:
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### assign
+### shift
 
-Take `Object` and add new field
+Return the first `Object` and close the feed
 Input file:
 
 ```json
@@ -916,9 +628,7 @@ Input file:
 Script:
 
 ```ini
-[assign]
-path = b.c
-value = 'X'
+[shift]
 ```
 
 Output:
@@ -926,29 +636,319 @@ Output:
 ```json
 [{
    a: 1,
-   b: { c: "X" },
+}]
+```
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### shuffle
+
+Take `Object`, shuffle data of the whole object or only some fields specified by path
+Input file:
+
+```json
+[{
+   a: 'abcdefg',
+   b: '1234567',
 },
 {
-   a: 2,
-   b: { c: "X" },
+   a: 'abcdefg',
+   b: '1234567',
+}]
+```
+
+Script:
+
+```ini
+[shuffle]
+path = a
+```
+
+Output:
+
+```json
+[{
+   a: 'cadbefg',
+   b: '1234567',
 },
 {
-   a: 3,
-   b: { c: "X" },
-},
-{
-   a: 4,
-   b: { c: "X" },
-},
-{
-   a: 5,
-   b: { c: "X" },
+   a: 'dcaegbf',
+   b: '1234567',
 }]
 ```
 
 #### Parameters
 
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the new field
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value of the new field
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of field to shuffle
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### spawn
+
+Take `Object` and delegate processing to an external pipeline, throw each chunk from the result
+Note : works like [delegate], but each chunk use its own external pipeline
+
+#### Parameters
+
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `cache` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Use a specific ezs statement to run commands (advanced)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### swing
+
+Takes an `Object` delegate processing to an external pipeline
+under specifics conditions
+Note : works like [spawn], but each chunk share the same external pipeline
+
+#### Parameters
+
+-   `test` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** if test is true
+-   `reverse` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reverse the test (optional, default `false`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### time
+
+Measure the execution time of a script, on each chunk on input.
+
+#### Parameters
+
+-   `script` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+
+#### Examples
+
+Input
+
+
+```javascript
+[1]
+```
+
+Program
+
+
+```javascript
+const script = `
+[transit]
+`;
+from([1])
+    .pipe(ezs('time', { script }))
+```
+
+Output
+
+
+```javascript
+[{
+  data: 1,
+  time: 15 // milliseconds
+}]
+```
+
+Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### tracer
+
+Take `Object`, print a character and throw the same object.
+Useful to see the progress in the stream.
+
+#### Parameters
+
+-   `print` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at each object (optional, default `.`)
+-   `last` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at last call (optional, default `.`)
+-   `first` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** character to print at first call (optional, default `.`)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### transit
+
+Take `Object` and throw the same object
+Input file:
+
+```json
+[{
+   a: 1,
+},
+{
+   a: 2,
+}]
+```
+
+Script:
+
+```ini
+[transit]
+```
+
+Output:
+
+```json
+[{
+   a: 1,
+},
+{
+   a: 2,
+}]
+```
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### truncate
+
+Takes all the chunks, and closes the feed when the total length is equal to the parameter
+Input file:
+
+```json
+[{
+   a: 1,
+},
+{
+   a: 2,
+},
+{
+   a: 3,
+},
+{
+   a: 4,
+},
+{
+   a: 5,
+}]
+```
+
+Script:
+
+```ini
+[truncate]
+length = 3
+```
+
+Output:
+
+```json
+[{
+   a: 1,
+},
+{
+   a: 2,
+},
+{
+   a: 3,
+}]
+```
+
+#### Parameters
+
+-   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Length of the feed
+
+Returns **any** 
+
+### ungroup
+
+-   **See: group
+    **
+
+Take all `chunk`s, and throw one item for every chunk
+
+```json
+[
+     [ 'a', 'b', 'c' ],
+     [ 'd', 'e', 'f' ],
+     [ 'g', 'h' ],
+]
+```
+
+Script:
+
+```ini
+[ungroup]
+```
+
+Output:
+
+```json
+[
+     'a',
+     'b',
+     'c',
+     'd',
+     'e',
+     'f',
+     'g',
+     'h',
+]
+```
+
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### unpack
+
+Take `String` and throw `Object` builded by JSON.parse on each line
+
+Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### validate
+
+-   **See: laravel validator rules
+    **
+-   **See: <https://github.com/skaterdav85/validatorjs#readme>
+    **
+
+From a `Object`, throw the same object if all rules pass
+
+Input file:
+
+```json
+[{
+   a: 1,
+   b: 'titi',
+},
+{
+   a: 2,
+   b: 'toto',
+},
+{
+   a: false,
+},
+]
+```
+
+Script:
+
+```ini
+[validate]
+path = a
+rule = required|number
+
+path = a
+rule = required|string
+```
+
+Output:
+
+```json
+[{
+   a: 1,
+   b: 'titi',
+},
+{
+   a: 2,
+   b: 'toto',
+},
+}]
+```
+
+#### Parameters
+
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** path of the field
+-   `rule` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** rule to validate the field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
         "ezs": "./bin/ezs"
     },
     "scripts": {
-        "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-core.md --section=usage && cp ../../docs/plugin-core.md ./README.md",
+        "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-core.md --section=usage && cp ../../docs/plugin-core.md ./README.md",
         "lint": "eslint --ext=.js ./test/*.js ./src/*.js ./src/statements/*.js",
         "build": "babel --root-mode upward src --out-dir lib",
         "prepublish": "npm run build",

--- a/packages/istex/README.md
+++ b/packages/istex/README.md
@@ -14,8 +14,8 @@ npm install @ezs/istex
 
 #### Table of Contents
 
--   [ISTEXUnzip](#istexunzip)
 -   [ISTEXFiles](#istexfiles)
+-   [ISTEXUnzip](#istexunzip)
 -   [ISTEXFilesContent](#istexfilescontent)
 -   [ISTEXResult](#istexresult)
 -   [ISTEXFacet](#istexfacet)
@@ -27,15 +27,6 @@ npm install @ezs/istex
 -   [ISTEXTriplify](#istextriplify)
 -   [ISTEXUniq](#istexuniq)
 -   [ISTEX](#istex)
-
-### ISTEXUnzip
-
-Take the content of a zip file, extract JSON files, and yield JSON objects.
-
-The zip file comes from dl.istex.fr, and the `manifest.json` is not
-extracted.
-
-Returns **any** Array<Object>
 
 ### ISTEXFiles
 
@@ -52,6 +43,15 @@ Take an Object with ISTEX `id` and generate an object for each file
 -   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
+
+### ISTEXUnzip
+
+Take the content of a zip file, extract JSON files, and yield JSON objects.
+
+The zip file comes from dl.istex.fr, and the `manifest.json` is not
+extracted.
+
+Returns **any** Array<Object>
 
 ### ISTEXFilesContent
 

--- a/packages/istex/README.md
+++ b/packages/istex/README.md
@@ -14,75 +14,43 @@ npm install @ezs/istex
 
 #### Table of Contents
 
--   [ISTEXFiles](#istexfiles)
--   [ISTEXUnzip](#istexunzip)
--   [ISTEXFilesContent](#istexfilescontent)
--   [ISTEXResult](#istexresult)
+-   [ISTEX](#istex)
 -   [ISTEXFacet](#istexfacet)
--   [ISTEXFilesWrap](#istexfileswrap)
--   [ISTEXScroll](#istexscroll)
 -   [ISTEXFetch](#istexfetch)
+-   [ISTEXFiles](#istexfiles)
+-   [ISTEXFilesContent](#istexfilescontent)
+-   [ISTEXFilesWrap](#istexfileswrap)
 -   [ISTEXParseDotCorpus](#istexparsedotcorpus)
+-   [ISTEXResult](#istexresult)
 -   [ISTEXSave](#istexsave)
+-   [ISTEXScroll](#istexscroll)
 -   [ISTEXTriplify](#istextriplify)
 -   [ISTEXUniq](#istexuniq)
--   [ISTEX](#istex)
+-   [ISTEXUnzip](#istexunzip)
 
-### ISTEXFiles
+### ISTEX
 
--   **See: ISTEXScroll
-    **
-
-Take an Object with ISTEX `id` and generate an object for each file
+Take an array and returns matching documents for every value of the array
 
 #### Parameters
 
--   `fulltext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** typology of the document to save (optional, default `pdf`)
--   `metadata` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** format of the files to save (optional, default `json`)
--   `enrichment` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** enrichment of the document to save
--   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
+-   `query` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** ISTEX query (or queries) (optional, default `data.query||[]`)
+-   `id` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** ISTEX id (or ids) (optional, default `data.id||[]`)
+-   `maxPage` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** maximum number of pages to get
+-   `size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of each page of results
+-   `duration` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** maximum duration between two requests (ex: "30s")
+-   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** fields to output
 
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
+#### Examples
 
-### ISTEXUnzip
-
-Take the content of a zip file, extract JSON files, and yield JSON objects.
-
-The zip file comes from dl.istex.fr, and the `manifest.json` is not
-extracted.
-
-Returns **any** Array<Object>
-
-### ISTEXFilesContent
-
--   **See: ISTEXFiles
-    **
-
-Take an Object with ISTEX `source` and check the document's file.
-Warning: to access fulltext, you have to give a `token` parameter.
-ISTEXFetch produces the stream you need to save the file.
-
-#### Parameters
-
--   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
--   `token` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** authentication token (see [documentation](https://doc.istex.fr/api/access/fede.html#acc%C3%A8s-programmatique-via-un-token-didentification))
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### ISTEXResult
-
--   **See: ISTEXScroll
-    **
-
-Take `Object` containing results of ISTEX API, and returns `hits` value
-(documents).
-
-This should be placed after ISTEXScroll.
-
-#### Parameters
-
--   `source` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `data`)
--   `target` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `feed`)
+```javascript
+.pipe(ezs('ISTEX', {
+  query: 'this is a test',
+  size: 3,
+  maxPage: 1,
+  sid: 'test'
+}))
+```
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
 
@@ -102,42 +70,6 @@ aggregations from the ISTEX API.
 ```javascript
 from([{ query: 'ezs', facet: 'corpusName' }])
   .pipe(ezs('ISTEXFacet', { sid: 'test', }))
-```
-
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
-
-### ISTEXFilesWrap
-
--   **See: ISTEXFiles
-    **
-
-Take and Object with ISTEX `stream` and wrap into a single zip
-
-Returns **[Buffer](https://nodejs.org/api/buffer.html)** 
-
-### ISTEXScroll
-
-Take an object containing a query string field and output records from the
-ISTEX API. Every output record is merged with the input object.
-
-#### Parameters
-
--   `query` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** ISTEX query (optional, default `input`)
--   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
--   `maxPage` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Maximum number of pages to get
--   `size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of each page of results (optional, default `2000`)
--   `duration` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** maximum duration between two requests (optional, default `"5m"`)
--   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** fields to get (optional, default `["doi"]`)
-
-#### Examples
-
-```javascript
-from([{ query: 'this is a test' }])
-  .pipe(ezs('ISTEXScroll', {
-      maxPage: 2,
-      size: 1,
-      sid: 'test',
-  }))
 ```
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
@@ -175,6 +107,47 @@ will produce two JSON records.
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
 
+### ISTEXFiles
+
+-   **See: ISTEXScroll
+    **
+
+Take an Object with ISTEX `id` and generate an object for each file
+
+#### Parameters
+
+-   `fulltext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** typology of the document to save (optional, default `pdf`)
+-   `metadata` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** format of the files to save (optional, default `json`)
+-   `enrichment` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** enrichment of the document to save
+-   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
+
+### ISTEXFilesContent
+
+-   **See: ISTEXFiles
+    **
+
+Take an Object with ISTEX `source` and check the document's file.
+Warning: to access fulltext, you have to give a `token` parameter.
+ISTEXFetch produces the stream you need to save the file.
+
+#### Parameters
+
+-   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
+-   `token` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** authentication token (see [documentation](https://doc.istex.fr/api/access/fede.html#acc%C3%A8s-programmatique-via-un-token-didentification))
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### ISTEXFilesWrap
+
+-   **See: ISTEXFiles
+    **
+
+Take and Object with ISTEX `stream` and wrap into a single zip
+
+Returns **[Buffer](https://nodejs.org/api/buffer.html)** 
+
 ### ISTEXParseDotCorpus
 
 Parse a `.corpus` file content, and execute the action contained in the
@@ -208,6 +181,23 @@ id 2FF3F5B1477986B9C617BB75CA3333DBEE99EB05
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### ISTEXResult
+
+-   **See: ISTEXScroll
+    **
+
+Take `Object` containing results of ISTEX API, and returns `hits` value
+(documents).
+
+This should be placed after ISTEXScroll.
+
+#### Parameters
+
+-   `source` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `data`)
+-   `target` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `feed`)
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
+
 ### ISTEXSave
 
 -   **See: ISTEXFetch
@@ -226,6 +216,33 @@ ISTEXFetch produces the stream you need to save the file.
 -   `token` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** authentication token (see [documentation](https://doc.istex.fr/api/access/fede.html#acc%C3%A8s-programmatique-via-un-token-didentification))
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
+
+### ISTEXScroll
+
+Take an object containing a query string field and output records from the
+ISTEX API. Every output record is merged with the input object.
+
+#### Parameters
+
+-   `query` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** ISTEX query (optional, default `input`)
+-   `sid` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** User-agent identifier (optional, default `"ezs-istex"`)
+-   `maxPage` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Maximum number of pages to get
+-   `size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of each page of results (optional, default `2000`)
+-   `duration` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** maximum duration between two requests (optional, default `"5m"`)
+-   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** fields to get (optional, default `["doi"]`)
+
+#### Examples
+
+```javascript
+from([{ query: 'this is a test' }])
+  .pipe(ezs('ISTEXScroll', {
+      maxPage: 2,
+      size: 1,
+      sid: 'test',
+  }))
+```
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
 
 ### ISTEXTriplify
 
@@ -325,28 +342,11 @@ Output
 <https://api.istex.fr/ark:/67375/NVC-JMPZTKTT-R> <https://data.istex.fr/ontology/istex#affiliation> "Department of Public Health, University of Sydney, Australia." .
 ```
 
-### ISTEX
+### ISTEXUnzip
 
-Take an array and returns matching documents for every value of the array
+Take the content of a zip file, extract JSON files, and yield JSON objects.
 
-#### Parameters
+The zip file comes from dl.istex.fr, and the `manifest.json` is not
+extracted.
 
--   `query` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** ISTEX query (or queries) (optional, default `data.query||[]`)
--   `id` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** ISTEX id (or ids) (optional, default `data.id||[]`)
--   `maxPage` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** maximum number of pages to get
--   `size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** size of each page of results
--   `duration` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** maximum duration between two requests (ex: "30s")
--   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** fields to output
-
-#### Examples
-
-```javascript
-.pipe(ezs('ISTEX', {
-  query: 'this is a test',
-  size: 3,
-  maxPage: 1,
-  sid: 'test'
-}))
-```
-
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
+Returns **any** Array<Object>

--- a/packages/istex/package.json
+++ b/packages/istex/package.json
@@ -30,7 +30,7 @@
     },
     "homepage": "https://github.com/Inist-CNRS/ezs/tree/master/packages/istex#readme",
     "scripts": {
-        "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-istex.md --section=usage  && cp ../../docs/plugin-istex.md ./README.md",
+        "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-istex.md --section=usage  && cp ../../docs/plugin-istex.md ./README.md",
         "lint": "eslint --ext=.js ./test/*.js ./src/*.js",
         "build": "babel --root-mode upward src --out-dir lib",
         "prepublish": "npm run build",

--- a/packages/lodex/README.md
+++ b/packages/lodex/README.md
@@ -14,56 +14,36 @@ npm install @ezs/core
 
 #### Table of Contents
 
--   [objects2columns](#objects2columns)
 -   [convertJsonLdToNQuads](#convertjsonldtonquads)
--   [LodexGetFields](#lodexgetfields)
--   [parseNQuads](#parsenquads)
 -   [convertToAtom](#converttoatom)
--   [LodexAggregateQuery](#lodexaggregatequery)
--   [LodexRunQuery](#lodexrunquery)
--   [LodexJoinQuery](#lodexjoinquery)
--   [LodexReduceQuery](#lodexreducequery)
--   [LodexInjectSyndicationFrom](#lodexinjectsyndicationfrom)
--   [Field](#field)
+-   [convertToExtendedJsonLd](#converttoextendedjsonld)
 -   [extractIstexQuery](#extractistexquery)
--   [LodexOutput](#lodexoutput)
--   [LodexGetCharacteristics](#lodexgetcharacteristics)
+-   [Field](#field)
+-   [flattenPatch](#flattenpatch)
+-   [getLastCharacteristic](#getlastcharacteristic)
+-   [getParam](#getparam)
 -   [injectDatasetFields](#injectdatasetfields)
 -   [keyMapping](#keymapping)
--   [LodexBuildContext](#lodexbuildcontext)
--   [flattenPatch](#flattenpatch)
 -   [labelizeFieldID](#labelizefieldid)
--   [getParam](#getparam)
--   [convertToExtendedJsonLd](#converttoextendedjsonld)
--   [getLastCharacteristic](#getlastcharacteristic)
+-   [LodexAggregateQuery](#lodexaggregatequery)
+-   [LodexBuildContext](#lodexbuildcontext)
+-   [LodexGetCharacteristics](#lodexgetcharacteristics)
+-   [LodexGetFields](#lodexgetfields)
 -   [LodexInjectCountFrom](#lodexinjectcountfrom)
+-   [LodexInjectSyndicationFrom](#lodexinjectsyndicationfrom)
+-   [LodexJoinQuery](#lodexjoinquery)
+-   [LodexOutput](#lodexoutput)
+-   [LodexReduceQuery](#lodexreducequery)
+-   [LodexRunQuery](#lodexrunquery)
+-   [objects2columns](#objects2columns)
+-   [parseNQuads](#parsenquads)
 -   [writeTurtle](#writeturtle)
-
-### objects2columns
-
-Take `Object` and ...
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### convertJsonLdToNQuads
 
 Take a JSON-LD object and transform it into NQuads triples.
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### LodexGetFields
-
-Return the fields (the model) of a LODEX.
-
-#### Parameters
-
--   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
-
-### parseNQuads
-
-Take N-Quads string and transform it to Objects.
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### convertToAtom
 
@@ -78,121 +58,16 @@ model.
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
-### LodexAggregateQuery
+### convertToExtendedJsonLd
 
-Take `Object` containing a MongoDB aggregate query and throw the result
+Convert the result of an ISTEX query to an extended JSON-LD.
 
-The input object must contain a `connectionStringURI` property, containing
-the connection string to MongoDB.
-
-#### Parameters
-
--   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
--   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
--   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** MongoDB filter
--   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### LodexRunQuery
-
-Take `Object` containing a MongoDB query and throw the result
-
-The input object must contain a `connectionStringURI` property, containing
-the connection string to MongoDB.
+Every hit must contain the URI of original lodex resource, linked to the
+query.
 
 #### Parameters
 
--   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
--   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
--   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** MongoDB filter
--   `sortOn` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Field to sort on
--   `sortOrder` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Oder to sort
--   `field` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** limit the result to some fields (optional, default `"uri"`)
--   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### LodexJoinQuery
-
-Take 3 parametres and creates a join query (one to many, on sub-ressource)
-
-The input object must contain a `connectionStringURI` property, valued with
-the connection string to MongoDB.
-
-#### Parameters
-
--   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
--   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
--   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** MongoDB filter (optional, default `{}`)
--   `sortOn` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Field to sort on
--   `sortOrder` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Oder to sort
--   `matchField` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Lodex field, containing matchable element
--   `matchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Value used with the match field to get items
--   `joinField` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Lodex field used for the join request
--   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### LodexReduceQuery
-
-Take an `Object` containing a MongoDB query, and a reducer, then throw the
-result.
-
-The input object must contain a `connectionStringURI` property, containing
-the connection string to MongoDB.
-
-#### Parameters
-
--   `reducer` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the reducer to use
--   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
--   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** MongoDB filter (optional, default `{}`)
--   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** limit the result to some fields (optional, default `"uri"`)
--   `minValue` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `maxValue` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
--   `maxSize` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** limit the result (optional, default `1000000`)
--   `orderBy` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** sort the result
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### LodexInjectSyndicationFrom
-
-Inject title & description (syndicationà from field what conatsin the uri of one resource
-
-#### Parameters
-
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Field path contains URI
--   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
-
-#### Examples
-
-Output:
-
-
-```javascript
-[
-  {
-{
-      "id": "uri:/ZD44DSQ",
-      "id-title": "Titre de la ressource uri:/ZD44DSQ",
-      "id-description": "Description de la ressource uri:/ZD44DSQ",
-      "value": 10
-    }
-  }
-]
-```
-
-### Field
-
-Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>
-
-#### Properties
-
--   `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The identifier of the field.
--   `scheme` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The semantic property of the field.
+-   `schemeForIstexQuery` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** URI to put between document and resource
 
 ### extractIstexQuery
 
@@ -216,85 +91,72 @@ Output:
 }
 ```
 
-### LodexOutput
+### Field
 
-Format the output in compliance with LODEX routines format.
+Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>
 
-#### Parameters
+#### Properties
 
--   `keyName` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** name of the `data` property (optional, default `data`)
--   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent or not (optional, default `false`)
--   `extract` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>?** fields to put at the root of the output
-                                      object
+-   `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The identifier of the field.
+-   `scheme` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The semantic property of the field.
 
-#### Examples
+### flattenPatch
 
-Input
+Take `Object` and transform all key ending byu number on array.
 
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-```javascript
-[
-     { _id: 1, value: 2, total: 2 },
-     { _id: 2, value: 4, total: 2 }
-]
-```
+### getLastCharacteristic
 
-Script
-
-
-```javascript
-.pipe(ezs('LodexOutput', { extract: 'total' }))
-```
-
-Output
-
-
-```javascript
-{
-    data [
-        { _id: 1, value: 2 },
-        { _id: 2, value: 4 }
-    ],
-    total: 2
-}
-```
-
-Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### LodexGetCharacteristics
-
-Return the last characteristics (the dataset covering fields) of a LODEX.
-
-#### Parameters
-
--   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
+Get last characteristic (list of all dataset covering fields).
 
 #### Examples
 
-Output:
+Input:
 
 
 ```javascript
 [
   {
-    "characteristics": {
-      "_id": "5d289071340bb500201b5146",
-      "qW6w": "Catégories WOS",
-      "ImiI": "Cette table correspond aux catégories Web Of Science.",
-      "alRS": "/api/run/syndication",
-      "aDLT": "Dans le cadre de l'enrichissement des documents du...",
-      "SFvt": "https://enrichment-process.data.istex.fr/ark:/67375/R0H-PWBRNFQ8-H",
-      "RzXW": "https://docs.google.com/drawings/d/1LzjO-oD6snh0MYfqxfPB7q-LU6Dev1SRmJstXFGzgvg/pub?w=960&h=720",
-      "E4jH": "https://www.etalab.gouv.fr/licence-ouverte-open-licence",
-      "MvkG": "Plateforme ISTEX",
-      "m7G5": "Inist-CNRS",
-      "1TvM": "2016-05-12",
-      "WcNl": "2019-01-16",
-      "publicationDate": "2019-07-12T13:51:45.129Z"
-    }
+    "_id" : ObjectId("5ca32c64019f45001d2b602d"),
+    "publicationDate" : ISODate("2019-04-02T09:33:24.463Z")
+  },
+  {
+    "_id" : ObjectId("5cee50bb019f45001d2b602f"),
+    "publicationDate" : ISODate("2019-05-29T09:28:27.773Z")
+  },
+  {
+    "_id" : ObjectId("5cee5119019f45001d2b6031"),
+    "publicationDate" : ISODate("2019-05-29T09:30:01.319Z")
+  },
+  {
+    "_id" : ObjectId("5cee5153019f45001d2b6032"),
+    "publicationDate" : ISODate("2019-05-29T09:30:59.770Z")
+  },
+  {
+    "_id" : ObjectId("5cee5160019f45001d2b6033"),
+    "publicationDate" : ISODate("2019-05-29T09:31:12.503Z")
+  },
+  {
+    "_id" : ObjectId("5cee530e3e9676001909ba24"),
+    "publicationDate" : ISODate("2019-05-29T09:38:22.569Z")
   }
 ]
 ```
+
+Output:
+
+
+```javascript
+{
+  "_id" : ObjectId("5cee530e3e9676001909ba24"),
+  "publicationDate" : ISODate("2019-05-29T09:38:22.569Z")
+}
+```
+
+Returns **any** 
+
+### getParam
 
 ### injectDatasetFields
 
@@ -376,24 +238,6 @@ Output
 
 Returns **any** Same object with modified keys
 
-### LodexBuildContext
-
-Take `Object` containing a URL query and throw a Context Object
-compatible with runQuery or reduceQuery
-
-#### Parameters
-
--   `connectionStringURI` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** to connect to MongoDB (optional, default `"mongodb://ezmaster_db:27017"`)
--   `host` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** to set host (usefull to build some links)
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### flattenPatch
-
-Take `Object` and transform all key ending byu number on array.
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### labelizeFieldID
 
 Inject in each item the last characteristics (the dataset covering fields) of a LODEX.
@@ -433,68 +277,77 @@ Output:
 ]
 ```
 
-### getParam
+### LodexAggregateQuery
 
-### convertToExtendedJsonLd
+Take `Object` containing a MongoDB aggregate query and throw the result
 
-Convert the result of an ISTEX query to an extended JSON-LD.
-
-Every hit must contain the URI of original lodex resource, linked to the
-query.
+The input object must contain a `connectionStringURI` property, containing
+the connection string to MongoDB.
 
 #### Parameters
 
--   `schemeForIstexQuery` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** URI to put between document and resource
+-   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
+-   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
+-   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** MongoDB filter
+-   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
 
-### getLastCharacteristic
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-Get last characteristic (list of all dataset covering fields).
+### LodexBuildContext
+
+Take `Object` containing a URL query and throw a Context Object
+compatible with runQuery or reduceQuery
+
+#### Parameters
+
+-   `connectionStringURI` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** to connect to MongoDB (optional, default `"mongodb://ezmaster_db:27017"`)
+-   `host` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** to set host (usefull to build some links)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### LodexGetCharacteristics
+
+Return the last characteristics (the dataset covering fields) of a LODEX.
+
+#### Parameters
+
+-   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
 
 #### Examples
-
-Input:
-
-
-```javascript
-[
-  {
-    "_id" : ObjectId("5ca32c64019f45001d2b602d"),
-    "publicationDate" : ISODate("2019-04-02T09:33:24.463Z")
-  },
-  {
-    "_id" : ObjectId("5cee50bb019f45001d2b602f"),
-    "publicationDate" : ISODate("2019-05-29T09:28:27.773Z")
-  },
-  {
-    "_id" : ObjectId("5cee5119019f45001d2b6031"),
-    "publicationDate" : ISODate("2019-05-29T09:30:01.319Z")
-  },
-  {
-    "_id" : ObjectId("5cee5153019f45001d2b6032"),
-    "publicationDate" : ISODate("2019-05-29T09:30:59.770Z")
-  },
-  {
-    "_id" : ObjectId("5cee5160019f45001d2b6033"),
-    "publicationDate" : ISODate("2019-05-29T09:31:12.503Z")
-  },
-  {
-    "_id" : ObjectId("5cee530e3e9676001909ba24"),
-    "publicationDate" : ISODate("2019-05-29T09:38:22.569Z")
-  }
-]
-```
 
 Output:
 
 
 ```javascript
-{
-  "_id" : ObjectId("5cee530e3e9676001909ba24"),
-  "publicationDate" : ISODate("2019-05-29T09:38:22.569Z")
-}
+[
+  {
+    "characteristics": {
+      "_id": "5d289071340bb500201b5146",
+      "qW6w": "Catégories WOS",
+      "ImiI": "Cette table correspond aux catégories Web Of Science.",
+      "alRS": "/api/run/syndication",
+      "aDLT": "Dans le cadre de l'enrichissement des documents du...",
+      "SFvt": "https://enrichment-process.data.istex.fr/ark:/67375/R0H-PWBRNFQ8-H",
+      "RzXW": "https://docs.google.com/drawings/d/1LzjO-oD6snh0MYfqxfPB7q-LU6Dev1SRmJstXFGzgvg/pub?w=960&h=720",
+      "E4jH": "https://www.etalab.gouv.fr/licence-ouverte-open-licence",
+      "MvkG": "Plateforme ISTEX",
+      "m7G5": "Inist-CNRS",
+      "1TvM": "2016-05-12",
+      "WcNl": "2019-01-16",
+      "publicationDate": "2019-07-12T13:51:45.129Z"
+    }
+  }
+]
 ```
 
-Returns **any** 
+### LodexGetFields
+
+Return the fields (the model) of a LODEX.
+
+#### Parameters
+
+-   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
 
 ### LodexInjectCountFrom
 
@@ -544,6 +397,153 @@ field = publicationDate
           { id: 7, value:2011, value_count:2  },
 ]
 ````
+
+### LodexInjectSyndicationFrom
+
+Inject title & description (syndicationà from field what conatsin the uri of one resource
+
+#### Parameters
+
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Field path contains URI
+-   `connectionStringURI` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** MongoDB connection string
+
+#### Examples
+
+Output:
+
+
+```javascript
+[
+  {
+{
+      "id": "uri:/ZD44DSQ",
+      "id-title": "Titre de la ressource uri:/ZD44DSQ",
+      "id-description": "Description de la ressource uri:/ZD44DSQ",
+      "value": 10
+    }
+  }
+]
+```
+
+### LodexJoinQuery
+
+Take 3 parametres and creates a join query (one to many, on sub-ressource)
+
+The input object must contain a `connectionStringURI` property, valued with
+the connection string to MongoDB.
+
+#### Parameters
+
+-   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
+-   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
+-   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** MongoDB filter (optional, default `{}`)
+-   `sortOn` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Field to sort on
+-   `sortOrder` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Oder to sort
+-   `matchField` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Lodex field, containing matchable element
+-   `matchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Value used with the match field to get items
+-   `joinField` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Lodex field used for the join request
+-   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### LodexOutput
+
+Format the output in compliance with LODEX routines format.
+
+#### Parameters
+
+-   `keyName` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** name of the `data` property (optional, default `data`)
+-   `indent` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indent or not (optional, default `false`)
+-   `extract` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>?** fields to put at the root of the output
+                                      object
+
+#### Examples
+
+Input
+
+
+```javascript
+[
+     { _id: 1, value: 2, total: 2 },
+     { _id: 2, value: 4, total: 2 }
+]
+```
+
+Script
+
+
+```javascript
+.pipe(ezs('LodexOutput', { extract: 'total' }))
+```
+
+Output
+
+
+```javascript
+{
+    data [
+        { _id: 1, value: 2 },
+        { _id: 2, value: 4 }
+    ],
+    total: 2
+}
+```
+
+Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### LodexReduceQuery
+
+Take an `Object` containing a MongoDB query, and a reducer, then throw the
+result.
+
+The input object must contain a `connectionStringURI` property, containing
+the connection string to MongoDB.
+
+#### Parameters
+
+-   `reducer` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the reducer to use
+-   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
+-   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** MongoDB filter (optional, default `{}`)
+-   `field` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** limit the result to some fields (optional, default `"uri"`)
+-   `minValue` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `maxValue` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `maxSize` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** limit the result (optional, default `1000000`)
+-   `orderBy` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** sort the result
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### LodexRunQuery
+
+Take `Object` containing a MongoDB query and throw the result
+
+The input object must contain a `connectionStringURI` property, containing
+the connection string to MongoDB.
+
+#### Parameters
+
+-   `collection` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** collection to use (optional, default `"publishedDataset"`)
+-   `referer` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** data injected into every result object
+-   `filter` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** MongoDB filter
+-   `sortOn` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Field to sort on
+-   `sortOrder` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Oder to sort
+-   `field` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** limit the result to some fields (optional, default `"uri"`)
+-   `limit` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+-   `skip` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** limit the result
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### objects2columns
+
+Take `Object` and ...
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### parseNQuads
+
+Take N-Quads string and transform it to Objects.
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### writeTurtle
 

--- a/packages/lodex/README.md
+++ b/packages/lodex/README.md
@@ -15,21 +15,21 @@ npm install @ezs/core
 #### Table of Contents
 
 -   [objects2columns](#objects2columns)
+-   [convertJsonLdToNQuads](#convertjsonldtonquads)
 -   [LodexGetFields](#lodexgetfields)
 -   [parseNQuads](#parsenquads)
--   [convertJsonLdToNQuads](#convertjsonldtonquads)
 -   [convertToAtom](#converttoatom)
 -   [LodexAggregateQuery](#lodexaggregatequery)
 -   [LodexRunQuery](#lodexrunquery)
 -   [LodexJoinQuery](#lodexjoinquery)
 -   [LodexReduceQuery](#lodexreducequery)
 -   [LodexInjectSyndicationFrom](#lodexinjectsyndicationfrom)
--   [LodexOutput](#lodexoutput)
--   [extractIstexQuery](#extractistexquery)
 -   [Field](#field)
--   [keyMapping](#keymapping)
+-   [extractIstexQuery](#extractistexquery)
+-   [LodexOutput](#lodexoutput)
 -   [LodexGetCharacteristics](#lodexgetcharacteristics)
 -   [injectDatasetFields](#injectdatasetfields)
+-   [keyMapping](#keymapping)
 -   [LodexBuildContext](#lodexbuildcontext)
 -   [flattenPatch](#flattenpatch)
 -   [labelizeFieldID](#labelizefieldid)
@@ -45,6 +45,12 @@ Take `Object` and ...
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### convertJsonLdToNQuads
+
+Take a JSON-LD object and transform it into NQuads triples.
+
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
 ### LodexGetFields
 
 Return the fields (the model) of a LODEX.
@@ -58,12 +64,6 @@ Return the fields (the model) of a LODEX.
 Take N-Quads string and transform it to Objects.
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### convertJsonLdToNQuads
-
-Take a JSON-LD object and transform it into NQuads triples.
-
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ### convertToAtom
 
@@ -185,6 +185,37 @@ Output:
 ]
 ```
 
+### Field
+
+Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>
+
+#### Properties
+
+-   `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The identifier of the field.
+-   `scheme` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The semantic property of the field.
+
+### extractIstexQuery
+
+Extract an ISTEX API query.
+
+#### Parameters
+
+-   `fields` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Field](#field)>** list of LODEX fields (optional, default `[]`)
+
+#### Examples
+
+Output:
+
+
+```javascript
+{
+   content: 'fake query',
+   lodex: {
+      uri: 'http://resource.uri',
+  },
+}
+```
+
 ### LodexOutput
 
 Format the output in compliance with LODEX routines format.
@@ -229,82 +260,6 @@ Output
 ```
 
 Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-### extractIstexQuery
-
-Extract an ISTEX API query.
-
-#### Parameters
-
--   `fields` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Field](#field)>** list of LODEX fields (optional, default `[]`)
-
-#### Examples
-
-Output:
-
-
-```javascript
-{
-   content: 'fake query',
-   lodex: {
-      uri: 'http://resource.uri',
-  },
-}
-```
-
-### Field
-
-Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>
-
-#### Properties
-
--   `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The identifier of the field.
--   `scheme` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The semantic property of the field.
-
-### keyMapping
-
-Take an object and map its keys to the one in mapping parameters.
-Keep keys absent in `from` parameter.
-
-#### Parameters
-
--   `from` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** keys of the input
--   `to` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** matching keys for the output
-
-#### Examples
-
-Input:
-
-
-```javascript
-[{
-  "dFgH": "Value",
-  "AaAa": "Value 2"
-}]
-```
-
-EZS:
-
-
-```javascript
-[keyMapping]
-from = dFgH
-to = Title
-from = AaAa
-to = Description
-```
-
-Output
-
-
-```javascript
-[{
-  "Title": "Value",
-  "Description": "Value 2"
-}]
-```
-
-Returns **any** Same object with modified keys
 
 ### LodexGetCharacteristics
 
@@ -375,6 +330,51 @@ Output:
   }
 ]
 ```
+
+### keyMapping
+
+Take an object and map its keys to the one in mapping parameters.
+Keep keys absent in `from` parameter.
+
+#### Parameters
+
+-   `from` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** keys of the input
+-   `to` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** matching keys for the output
+
+#### Examples
+
+Input:
+
+
+```javascript
+[{
+  "dFgH": "Value",
+  "AaAa": "Value 2"
+}]
+```
+
+EZS:
+
+
+```javascript
+[keyMapping]
+from = dFgH
+to = Title
+from = AaAa
+to = Description
+```
+
+Output
+
+
+```javascript
+[{
+  "Title": "Value",
+  "Description": "Value 2"
+}]
+```
+
+Returns **any** Same object with modified keys
 
 ### LodexBuildContext
 

--- a/packages/lodex/package.json
+++ b/packages/lodex/package.json
@@ -38,7 +38,7 @@
     },
     "main": "./lib/index.js",
     "scripts": {
-        "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-lodex.md --section=usage  && cp ../../docs/plugin-lodex.md ./README.md",
+        "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-lodex.md --section=usage  && cp ../../docs/plugin-lodex.md ./README.md",
         "lint": "eslint --ext=.js ./test/*.js ./src/*.js",
         "build": "babel --root-mode upward src --out-dir lib",
         "prepublish": "npm run build",

--- a/packages/loterre/README.md
+++ b/packages/loterre/README.md
@@ -17,9 +17,9 @@ npm install @ezs/loterre
 -   [checkIfPropertyExist](#checkifpropertyexist)
 -   [checkIfPropertyExist](#checkifpropertyexist-1)
 -   [checkIfPropertyExist](#checkifpropertyexist-2)
+-   [writeHierarchy](#writehierarchy)
 -   [getBroaderAndNarrower](#getbroaderandnarrower)
 -   [getBroaderAndNarrower](#getbroaderandnarrower-1)
--   [writeHierarchy](#writehierarchy)
 -   [writeEdge](#writeedge)
 -   [SKOSHierarchy](#skoshierarchy)
 -   [SKOSHierarchy](#skoshierarchy-1)
@@ -48,6 +48,17 @@ npm install @ezs/loterre
 -   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 -   `obj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### writeHierarchy
+
+#### Parameters
+
+-   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
 ### getBroaderAndNarrower
 
 #### Parameters
@@ -67,17 +78,6 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 -   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Returns object
-
-### writeHierarchy
-
-#### Parameters
-
--   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 ### writeEdge
 

--- a/packages/loterre/README.md
+++ b/packages/loterre/README.md
@@ -17,15 +17,15 @@ npm install @ezs/loterre
 -   [checkIfPropertyExist](#checkifpropertyexist)
 -   [checkIfPropertyExist](#checkifpropertyexist-1)
 -   [checkIfPropertyExist](#checkifpropertyexist-2)
--   [writeHierarchy](#writehierarchy)
 -   [getBroaderAndNarrower](#getbroaderandnarrower)
 -   [getBroaderAndNarrower](#getbroaderandnarrower-1)
--   [writeEdge](#writeedge)
 -   [SKOSHierarchy](#skoshierarchy)
 -   [SKOSHierarchy](#skoshierarchy-1)
 -   [SKOSObject](#skosobject)
 -   [SKOSPathEnum](#skospathenum)
 -   [SKOSPathEnum](#skospathenum-1)
+-   [writeEdge](#writeedge)
+-   [writeHierarchy](#writehierarchy)
 
 ### checkIfPropertyExist
 
@@ -47,17 +47,6 @@ npm install @ezs/loterre
 
 -   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 -   `obj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### writeHierarchy
-
-#### Parameters
-
--   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 ### getBroaderAndNarrower
 
@@ -78,17 +67,6 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 -   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Returns object
-
-### writeEdge
-
-#### Parameters
-
--   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 ### SKOSHierarchy
 
@@ -242,3 +220,25 @@ Output:
 -   `language` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Choose langauge of prefLabel (optional, default `en`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Returns object
+
+### writeEdge
+
+#### Parameters
+
+-   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+### writeHierarchy
+
+#### Parameters
+
+-   `data` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `feed` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `store` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `weight` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 

--- a/packages/loterre/package.json
+++ b/packages/loterre/package.json
@@ -28,7 +28,7 @@
         ]
     },
     "scripts": {
-        "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-loterre.md --section=usage && cp ../../docs/plugin-loterre.md ./README.md",
+        "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-loterre.md --section=usage && cp ../../docs/plugin-loterre.md ./README.md",
         "lint": "eslint --ext=.js ./test/*.js ./src/*.js",
         "build": "babel --root-mode upward src --out-dir lib",
         "prepublish": "npm run build",

--- a/packages/sparql/package.json
+++ b/packages/sparql/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "lint": "eslint --ext=.js ./test/*.js ./src/*.js",
-    "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-sparql.md --section=usage && cp ../../docs/plugin-sparql.md ./README.md",
+    "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-sparql.md --section=usage && cp ../../docs/plugin-sparql.md ./README.md",
     "build": "babel --root-mode upward src --out-dir lib",
     "prepublish": "npm run build",
     "preversion": "npm run doc"

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -16,23 +16,28 @@ npm install @ezs/storage
 
 #### Table of Contents
 
--   [load](#load)
--   [flow](#flow)
--   [save](#save)
--   [identify](#identify)
 -   [boost](#boost)
+-   [flow](#flow)
+-   [identify](#identify)
+-   [load](#load)
+-   [save](#save)
 
-### load
+### boost
 
-With a `String`, containing a URI throw all the documents that match
+Takes an `Object` delegate processing to an external pipeline and cache the result
 
 #### Parameters
 
 -   `data`  
 -   `feed`  
--   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (that should contains the uri input) (optional, default `ezs`)
+-   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
+-   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
+-   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
+-   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
+-   `key` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the cache key form the stream, in not provided, it's computed with the first chunk
+-   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Frequency (seconds) to cleanup the cache (EZS_DELAY) (optional, default `3600`)
 
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ### flow
 
@@ -45,20 +50,6 @@ Warning: order is not guaranteed
 -   `feed`  
 -   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (same for all objects) (optional, default `ezs`)
 -   `length` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** limit the number of output objects
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### save
-
-Take `Object`, to save it into a store and throw an URL
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path containing the object Identifier (optional, default `uri`)
--   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (same for all objects) (optional, default `ezs`)
--   `reset` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** if the store already exists, you will erase all previous content (optional, default `false`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -75,19 +66,28 @@ Take `Object`, and compute & add a identifier
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
-### boost
+### load
 
-Takes an `Object` delegate processing to an external pipeline and cache the result
+With a `String`, containing a URI throw all the documents that match
 
 #### Parameters
 
 -   `data`  
 -   `feed`  
--   `file` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a file
--   `script` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a string of characters
--   `commands` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a object
--   `command` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the external pipeline is described in a URL-like command
--   `key` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the cache key form the stream, in not provided, it's computed with the first chunk
--   `cleanupDelay` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Frequency (seconds) to cleanup the cache (EZS_DELAY) (optional, default `3600`)
+-   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (that should contains the uri input) (optional, default `ezs`)
+
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+### save
+
+Take `Object`, to save it into a store and throw an URL
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path containing the object Identifier (optional, default `uri`)
+-   `domain` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** domain ID (same for all objects) (optional, default `ezs`)
+-   `reset` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** if the store already exists, you will erase all previous content (optional, default `false`)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -30,7 +30,7 @@
   },
   "main": "./lib/index.js",
   "scripts": {
-    "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-storage.md --section=usage  && cp ../../docs/plugin-storage.md ./README.md",
+    "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-storage.md --section=usage  && cp ../../docs/plugin-storage.md ./README.md",
     "lint": "eslint --ext=.js ./test/*.js ./src/*.js",
     "build": "babel --root-mode upward src --out-dir lib",
     "prepublish": "npm run build",

--- a/packages/transformers/README.md
+++ b/packages/transformers/README.md
@@ -85,34 +85,34 @@ npm install @ezs/transformers
 -   [$ARRAY](#array)
 -   [$BOOLEAN](#boolean)
 -   [$CAPITALIZE](#capitalize)
+-   [$COLUMN](#column)
+-   [$CONCAT](#concat)
+-   [$CONCAT_URI](#concat_uri)
+-   [$DEFAULT](#default)
 -   [$FORMAT](#format)
+-   [$GET](#get)
+-   [$JOIN](#join)
 -   [$LOWERCASE](#lowercase)
+-   [$MAPPING](#mapping)
+-   [$MASK](#mask)
 -   [$NUMBER](#number)
 -   [$PARSE](#parse)
+-   [$PREFIX](#prefix)
+-   [$REMOVE](#remove)
+-   [$REPLACE](#replace)
+-   [$REPLACE_REGEX](#replace_regex)
+-   [$SELECT](#select)
+-   [$SHIFT](#shift)
+-   [$SPLIT](#split)
 -   [$STRING](#string)
+-   [$SUFFIX](#suffix)
 -   [$TRIM](#trim)
+-   [$TRUNCATE](#truncate)
+-   [$TRUNCATE_WORDS](#truncate_words)
 -   [$UNIQ](#uniq)
 -   [$UPPERCASE](#uppercase)
 -   [$URLENCODE](#urlencode)
--   [$COLUMN](#column)
--   [$DEFAULT](#default)
--   [$GET](#get)
--   [$JOIN](#join)
--   [$MASK](#mask)
--   [$PREFIX](#prefix)
--   [$REMOVE](#remove)
--   [$SHIFT](#shift)
--   [$SUFFIX](#suffix)
 -   [$VALUE](#value)
--   [$CONCAT](#concat)
--   [$MAPPING](#mapping)
--   [$SELECT](#select)
--   [$SPLIT](#split)
--   [$TRUNCATE_WORDS](#truncate_words)
--   [$TRUNCATE](#truncate)
--   [$CONCAT_URI](#concat_uri)
--   [$REPLACE_REGEX](#replace_regex)
--   [$REPLACE](#replace)
 
 ### $ARRAY
 
@@ -171,6 +171,94 @@ field = title
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### $COLUMN
+
+prendre une donnée dans un champ (colonne d'un fichier tabulé)
+
+Exemple :
+
+```ini
+[$COLUMN]
+field = newTitle
+column = oldTitle
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $CONCAT
+
+concaténer deux valeurs
+
+Exemple :
+
+```ini
+[$CONCAT]
+field = result
+columns = part1
+columns = part2
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
+-   `columns` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $CONCAT_URI
+
+compoer un identifiant avec plusieurs champs
+
+Exemple :
+
+```ini
+[$CONCAT_URI]
+field = identifiant
+column = nom
+column = prenom
+separator = -
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
+-   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get data
+-   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** glue between each column
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $DEFAULT
+
+donner une valeur par défaut
+
+Exemple :
+
+```ini
+[$DEFAULT]
+field = title
+alternative = not available
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `alternative` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use if field does not exist
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### $FORMAT
 
 appliquer un patron (template)
@@ -190,6 +278,48 @@ with = (%s:%s)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### $GET
+
+Récupére toutes les valeurs correspondant à un chemin (dot path)
+
+ Exemple :
+
+```ini
+[$GET]
+field = output
+path = input
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $JOIN
+
+Rassemble les valeurs d'un tableau en une chaîne de caractères
+
+ Exemple :
+
+```ini
+[$JOIN]
+field = output
+path = input
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation (must be an array)
+-   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** glue between each field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### $LOWERCASE
 
 mettre en bas de casse (minuscules)
@@ -206,6 +336,49 @@ field = title
 -   `data`  
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $MAPPING
+
+Opération permettant le remplacement à partir d'une table
+(équivalent à l'enchaînement de plusieurs opération REPLACE)
+
+Exemple :
+
+```ini
+[$MAPPING]
+field = keywords
+list = "hello":"bonjour", "hi":"salut"
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `list` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the mapping list
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $MASK
+
+S'assure que la valeur respecte une expression régulière
+
+Exemple :
+
+```ini
+[$MASK]
+field = title
+with = ^[a-z]+$
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the control
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -247,6 +420,157 @@ field = json
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### $PREFIX
+
+préfixer la valeur avec une chaîne de caractères
+
+Exemple :
+
+```ini
+[$PREFIX]
+field = title
+with = #
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `vith` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the begining of the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $REMOVE
+
+supprimer un élément ou une sous-chaîne
+
+Exemple :
+
+```ini
+[$REMOVE]
+field = title
+the = .
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `the` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value todrop in the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $REPLACE
+
+remplacer une chaîne par une autre
+
+Exemple :
+
+```ini
+[$REPLACE]
+field = title
+searchValue = 1
+replaceValue = un
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to search
+-   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $REPLACE_REGEX
+
+remplacer une chaîne par une autre via une exrpression régulière
+
+Exemple :
+
+```ini
+[$REPLACE_REGEX]
+field = title
+searchValue = $hel\w+
+replaceValue = bonjour
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** regex to search
+-   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SELECT
+
+Prendre une valeir dans un objet à partir de son chemin (dot path)
+
+Exemple :
+
+```ini
+[$SELECT]
+field = title
+path
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the selection
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SHIFT
+
+décaler une valeur multiple (tableau ou chaîne de caractères)
+
+Exemple :
+
+```ini
+[$SHIFT]
+field = title
+gap = 2
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many item or characters to drop
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SPLIT
+
+segmente une chaîne de caractères en tableau
+
+Exemple :
+
+```ini
+[$SPLIT]
+field = title
+separator = |
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to split the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### $STRING
 
 transforme la valeur en chaîne de caractères
@@ -266,6 +590,27 @@ field = title
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
+### $SUFFIX
+
+ajoute une chaîne de caractères à la fin d'une chaîne ou d'un tableau
+
+Exemple :
+
+```ini
+[$SUFFIX]
+field = title
+with = !
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `with` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the end of the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
 ### $TRIM
 
 enlève les espaces au début et à la fin d'une chaîne de caractères
@@ -282,6 +627,49 @@ field = title
 -   `data`  
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $TRUNCATE
+
+tronque, prend les premières valeurs d'un tableau, d'une chaîne
+
+Exemple :
+
+```ini
+[$TRUNCATE]
+field = title
+gap = 25
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many items or characters to keep
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $TRUNCATE_WORDS
+
+Opération permettant la troncature par nombre de mots
+et non pas par nombre de caractères comme pour opération TRUNCATE
+
+Exemple :
+
+```ini
+[$TRUNCATE_WORDS]
+field = title
+gap = 10
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many words to keep
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -342,195 +730,6 @@ field = url
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $COLUMN
-
-prendre une donnée dans un champ (colonne d'un fichier tabulé)
-
-Exemple :
-
-```ini
-[$COLUMN]
-field = newTitle
-column = oldTitle
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $DEFAULT
-
-donner une valeur par défaut
-
-Exemple :
-
-```ini
-[$DEFAULT]
-field = title
-alternative = not available
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `alternative` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use if field does not exist
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $GET
-
-Récupére toutes les valeurs correspondant à un chemin (dot path)
-
- Exemple :
-
-```ini
-[$GET]
-field = output
-path = input
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $JOIN
-
-Rassemble les valeurs d'un tableau en une chaîne de caractères
-
- Exemple :
-
-```ini
-[$JOIN]
-field = output
-path = input
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation (must be an array)
--   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** glue between each field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $MASK
-
-S'assure que la valeur respecte une expression régulière
-
-Exemple :
-
-```ini
-[$MASK]
-field = title
-with = ^[a-z]+$
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the control
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $PREFIX
-
-préfixer la valeur avec une chaîne de caractères
-
-Exemple :
-
-```ini
-[$PREFIX]
-field = title
-with = #
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `vith` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the begining of the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $REMOVE
-
-supprimer un élément ou une sous-chaîne
-
-Exemple :
-
-```ini
-[$REMOVE]
-field = title
-the = .
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `the` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value todrop in the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SHIFT
-
-décaler une valeur multiple (tableau ou chaîne de caractères)
-
-Exemple :
-
-```ini
-[$SHIFT]
-field = title
-gap = 2
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many item or characters to drop
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SUFFIX
-
-ajoute une chaîne de caractères à la fin d'une chaîne ou d'un tableau
-
-Exemple :
-
-```ini
-[$SUFFIX]
-field = title
-with = !
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `with` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the end of the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### $VALUE
 
 Fixer une valeur
@@ -549,204 +748,5 @@ value = Hello world
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** new field path
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to set the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $CONCAT
-
-concaténer deux valeurs
-
-Exemple :
-
-```ini
-[$CONCAT]
-field = result
-columns = part1
-columns = part2
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
--   `columns` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $MAPPING
-
-Opération permettant le remplacement à partir d'une table
-(équivalent à l'enchaînement de plusieurs opération REPLACE)
-
-Exemple :
-
-```ini
-[$MAPPING]
-field = keywords
-list = "hello":"bonjour", "hi":"salut"
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `list` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the mapping list
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SELECT
-
-Prendre une valeir dans un objet à partir de son chemin (dot path)
-
-Exemple :
-
-```ini
-[$SELECT]
-field = title
-path
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the selection
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SPLIT
-
-segmente une chaîne de caractères en tableau
-
-Exemple :
-
-```ini
-[$SPLIT]
-field = title
-separator = |
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to split the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $TRUNCATE_WORDS
-
-Opération permettant la troncature par nombre de mots
-et non pas par nombre de caractères comme pour opération TRUNCATE
-
-Exemple :
-
-```ini
-[$TRUNCATE_WORDS]
-field = title
-gap = 10
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many words to keep
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $TRUNCATE
-
-tronque, prend les premières valeurs d'un tableau, d'une chaîne
-
-Exemple :
-
-```ini
-[$TRUNCATE]
-field = title
-gap = 25
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many items or characters to keep
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $CONCAT_URI
-
-compoer un identifiant avec plusieurs champs
-
-Exemple :
-
-```ini
-[$CONCAT_URI]
-field = identifiant
-column = nom
-column = prenom
-separator = -
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
--   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get data
--   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** glue between each column
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $REPLACE_REGEX
-
-remplacer une chaîne par une autre via une exrpression régulière
-
-Exemple :
-
-```ini
-[$REPLACE_REGEX]
-field = title
-searchValue = $hel\w+
-replaceValue = bonjour
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** regex to search
--   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $REPLACE
-
-remplacer une chaîne par une autre
-
-Exemple :
-
-```ini
-[$REPLACE]
-field = title
-searchValue = 1
-replaceValue = un
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to search
--   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/packages/transformers/README.md
+++ b/packages/transformers/README.md
@@ -82,56 +82,37 @@ npm install @ezs/transformers
 
 #### Table of Contents
 
--   [$LOWERCASE](#lowercase)
 -   [$ARRAY](#array)
--   [$TRIM](#trim)
--   [$URLENCODE](#urlencode)
--   [$UPPERCASE](#uppercase)
--   [$FORMAT](#format)
+-   [$BOOLEAN](#boolean)
 -   [$CAPITALIZE](#capitalize)
--   [$UNIQ](#uniq)
+-   [$FORMAT](#format)
+-   [$LOWERCASE](#lowercase)
 -   [$NUMBER](#number)
 -   [$PARSE](#parse)
--   [$BOOLEAN](#boolean)
 -   [$STRING](#string)
+-   [$TRIM](#trim)
+-   [$UNIQ](#uniq)
+-   [$UPPERCASE](#uppercase)
+-   [$URLENCODE](#urlencode)
 -   [$COLUMN](#column)
+-   [$DEFAULT](#default)
 -   [$GET](#get)
 -   [$JOIN](#join)
--   [$DEFAULT](#default)
--   [$REMOVE](#remove)
--   [$VALUE](#value)
--   [$SUFFIX](#suffix)
 -   [$MASK](#mask)
--   [$SHIFT](#shift)
 -   [$PREFIX](#prefix)
--   [$SPLIT](#split)
+-   [$REMOVE](#remove)
+-   [$SHIFT](#shift)
+-   [$SUFFIX](#suffix)
+-   [$VALUE](#value)
+-   [$CONCAT](#concat)
+-   [$MAPPING](#mapping)
 -   [$SELECT](#select)
+-   [$SPLIT](#split)
 -   [$TRUNCATE_WORDS](#truncate_words)
 -   [$TRUNCATE](#truncate)
--   [$MAPPING](#mapping)
--   [$CONCAT](#concat)
 -   [$CONCAT_URI](#concat_uri)
--   [$REPLACE](#replace)
 -   [$REPLACE_REGEX](#replace_regex)
-
-### $LOWERCASE
-
-mettre en bas de casse (minuscules)
-
-Exemple :
-
-```ini
-[$LOWERCASE]
-field = title
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   [$REPLACE](#replace)
 
 ### $ARRAY
 
@@ -152,15 +133,15 @@ field = keywords
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $TRIM
+### $BOOLEAN
 
-enlève les espaces au début et à la fin d'une chaîne de caractères
+transformer une chaîne de caractères en booléen
 
 Exemple :
 
 ```ini
-[$TRIM]
-field = title
+[$BOOLEAN]
+field = haveMoney
 ```
 
 #### Parameters
@@ -171,33 +152,14 @@ field = title
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $URLENCODE
+### $CAPITALIZE
 
-encode une chaine comme dans une URL
-
-Exemple :
-
-```ini
-[$URLENCODE]
-field = url
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $UPPERCASE
-
-mettre la chaîne en majuscules
+mettre le premier caractère en majuscule
 
 Exemple :
 
 ```ini
-[$UPPERCASE]
+[$CAPITALIZE]
 field = title
 ```
 
@@ -228,14 +190,14 @@ with = (%s:%s)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $CAPITALIZE
+### $LOWERCASE
 
-mettre le premier caractère en majuscule
+mettre en bas de casse (minuscules)
 
 Exemple :
 
 ```ini
-[$CAPITALIZE]
+[$LOWERCASE]
 field = title
 ```
 
@@ -244,25 +206,6 @@ field = title
 -   `data`  
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $UNIQ
-
-dédoublonne les valeurs (dans un tableau)
-
-Exemple :
-
-```ini
-[$UNIQ]
-field = title
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation (must be an aarray)
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -304,15 +247,15 @@ field = json
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $BOOLEAN
+### $STRING
 
-transformer une chaîne de caractères en booléen
+transforme la valeur en chaîne de caractères
 
 Exemple :
 
 ```ini
-[$BOOLEAN]
-field = haveMoney
+[$STRING]
+field = title
 ```
 
 #### Parameters
@@ -323,15 +266,72 @@ field = haveMoney
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $STRING
+### $TRIM
 
-transforme la valeur en chaîne de caractères
+enlève les espaces au début et à la fin d'une chaîne de caractères
 
 Exemple :
 
 ```ini
-[$STRING]
+[$TRIM]
 field = title
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $UNIQ
+
+dédoublonne les valeurs (dans un tableau)
+
+Exemple :
+
+```ini
+[$UNIQ]
+field = title
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation (must be an aarray)
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $UPPERCASE
+
+mettre la chaîne en majuscules
+
+Exemple :
+
+```ini
+[$UPPERCASE]
+field = title
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $URLENCODE
+
+encode une chaine comme dans une URL
+
+Exemple :
+
+```ini
+[$URLENCODE]
+field = url
 ```
 
 #### Parameters
@@ -360,6 +360,27 @@ column = oldTitle
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
 -   `column` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $DEFAULT
+
+donner une valeur par défaut
+
+Exemple :
+
+```ini
+[$DEFAULT]
+field = title
+alternative = not available
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `alternative` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use if field does not exist
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -405,90 +426,6 @@ path = input
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $DEFAULT
-
-donner une valeur par défaut
-
-Exemple :
-
-```ini
-[$DEFAULT]
-field = title
-alternative = not available
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `alternative` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use if field does not exist
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $REMOVE
-
-supprimer un élément ou une sous-chaîne
-
-Exemple :
-
-```ini
-[$REMOVE]
-field = title
-the = .
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `the` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value todrop in the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $VALUE
-
-Fixer une valeur
-
-Exemple :
-
-```ini
-[$VALUE]
-field = title
-value = Hello world
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** new field path
--   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to set the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SUFFIX
-
-ajoute une chaîne de caractères à la fin d'une chaîne ou d'un tableau
-
-Exemple :
-
-```ini
-[$SUFFIX]
-field = title
-with = !
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `with` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the end of the field
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### $MASK
 
 S'assure que la valeur respecte une expression régulière
@@ -507,27 +444,6 @@ with = ^[a-z]+$
 -   `feed`  
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the control
 -   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use during the transformation
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $SHIFT
-
-décaler une valeur multiple (tableau ou chaîne de caractères)
-
-Exemple :
-
-```ini
-[$SHIFT]
-field = title
-gap = 2
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many item or characters to drop
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -552,16 +468,58 @@ with = #
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $SPLIT
+### $REMOVE
 
-segmente une chaîne de caractères en tableau
+supprimer un élément ou une sous-chaîne
 
 Exemple :
 
 ```ini
-[$SPLIT]
+[$REMOVE]
 field = title
-separator = |
+the = .
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `the` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value todrop in the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SHIFT
+
+décaler une valeur multiple (tableau ou chaîne de caractères)
+
+Exemple :
+
+```ini
+[$SHIFT]
+field = title
+gap = 2
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `gap` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** how many item or characters to drop
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SUFFIX
+
+ajoute une chaîne de caractères à la fin d'une chaîne ou d'un tableau
+
+Exemple :
+
+```ini
+[$SUFFIX]
+field = title
+with = !
 ```
 
 #### Parameters
@@ -569,7 +527,72 @@ separator = |
 -   `data`  
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to split the field
+-   `with` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to add at the end of the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $VALUE
+
+Fixer une valeur
+
+Exemple :
+
+```ini
+[$VALUE]
+field = title
+value = Hello world
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** new field path
+-   `value` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to set the field
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $CONCAT
+
+concaténer deux valeurs
+
+Exemple :
+
+```ini
+[$CONCAT]
+field = result
+columns = part1
+columns = part2
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
+-   `columns` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $MAPPING
+
+Opération permettant le remplacement à partir d'une table
+(équivalent à l'enchaînement de plusieurs opération REPLACE)
+
+Exemple :
+
+```ini
+[$MAPPING]
+field = keywords
+list = "hello":"bonjour", "hi":"salut"
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `list` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the mapping list
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -591,6 +614,27 @@ path
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the selection
 -   `path` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $SPLIT
+
+segmente une chaîne de caractères en tableau
+
+Exemple :
+
+```ini
+[$SPLIT]
+field = title
+separator = |
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `separator` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to use to split the field
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
@@ -637,50 +681,6 @@ gap = 25
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $MAPPING
-
-Opération permettant le remplacement à partir d'une table
-(équivalent à l'enchaînement de plusieurs opération REPLACE)
-
-Exemple :
-
-```ini
-[$MAPPING]
-field = keywords
-list = "hello":"bonjour", "hi":"salut"
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `list` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the mapping list
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
-### $CONCAT
-
-concaténer deux valeurs
-
-Exemple :
-
-```ini
-[$CONCAT]
-field = result
-columns = part1
-columns = part2
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get the result of the transformation
--   `columns` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to get value
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### $CONCAT_URI
 
 compoer un identifiant avec plusieurs champs
@@ -705,29 +705,6 @@ separator = -
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-### $REPLACE
-
-remplacer une chaîne par une autre
-
-Exemple :
-
-```ini
-[$REPLACE]
-field = title
-searchValue = 1
-replaceValue = un
-```
-
-#### Parameters
-
--   `data`  
--   `feed`  
--   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
--   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to search
--   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
-
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-
 ### $REPLACE_REGEX
 
 remplacer une chaîne par une autre via une exrpression régulière
@@ -747,6 +724,29 @@ replaceValue = bonjour
 -   `feed`  
 -   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
 -   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** regex to search
+-   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+### $REPLACE
+
+remplacer une chaîne par une autre
+
+Exemple :
+
+```ini
+[$REPLACE]
+field = title
+searchValue = 1
+replaceValue = un
+```
+
+#### Parameters
+
+-   `data`  
+-   `feed`  
+-   `field` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** field path to apply the transformation
+-   `searchValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to search
 -   `replaceValue` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** value to replace with
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 

--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -27,7 +27,7 @@
   },
   "main": "./lib/index.js",
   "scripts": {
-    "doc": "documentation readme src/* --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-transformers.md --section=usage  && cp ../../docs/plugin-transformers.md ./README.md",
+    "doc": "documentation readme src/* --sort-order=alpha --shallow --markdown-toc-max-depth=2 --readme-file=../../docs/plugin-transformers.md --section=usage  && cp ../../docs/plugin-transformers.md ./README.md",
     "lint": "eslint --ext=.js ./test/*.js ./src/*.js",
     "build": "babel --root-mode upward src --out-dir lib",
     "prepublish": "npm run build",


### PR DESCRIPTION
Sorting of statements in documentation change almost at every generation.

Let's add the  `--sort-order=alpha` option to documentation, for all plugins.