### PR TITLE
Add a test for combine and the use of two files with the same name in different directories

### DIFF
--- a/packages/analytics/test/a/combine.ini
+++ b/packages/analytics/test/a/combine.ini
@@ -1,0 +1,6 @@
+[use]
+plugin = analytics
+
+[combine]
+path = a
+file = ./getDirectory.ini

--- a/packages/analytics/test/a/getDirectory.ini
+++ b/packages/analytics/test/a/getDirectory.ini
@@ -1,0 +1,6 @@
+[replace]
+path = id
+value = 1
+
+path = value
+value = a

--- a/packages/analytics/test/b/combine.ini
+++ b/packages/analytics/test/b/combine.ini
@@ -1,0 +1,6 @@
+[use]
+plugin = analytics
+
+[combine]
+path = a
+file = ./getDirectory.ini

--- a/packages/analytics/test/b/getDirectory.ini
+++ b/packages/analytics/test/b/getDirectory.ini
@@ -1,0 +1,6 @@
+[replace]
+path = id
+value = a
+
+path = value
+value = b

--- a/packages/analytics/test/combine.js
+++ b/packages/analytics/test/combine.js
@@ -114,7 +114,7 @@ describe('combine', () => {
         `;
 
         from(input)
-                .pipe(ezs('combine', { path: 'b', script, default: 'n/a' }))
+            .pipe(ezs('combine', { path: 'b', script, default: 'n/a' }))
             .pipe(ezs.catch())
             .on('error', done)
             .on('data', (chunk) => {
@@ -243,6 +243,23 @@ describe('combine', () => {
                 assert.equal(output[4].b.value, 'ee');
                 assert.equal(output[5].b.value, 'ff');
                 done();
+            });
+    });
+    test('with 2 files with the same name', (done) => {
+        ezs.use(statements);
+        const input = [{ a: 1 }];
+        const output = [];
+
+        from(input)
+            .pipe(ezs('delegate', { file: './a/combine.ini' }))
+            .pipe(ezs('delegate', { file: './b/combine.ini' }))
+            .pipe(ezs.catch())
+            .on('error', done)
+            .on('data', (chunk) => {
+                output.push(chunk);
+            })
+            .on('end', () => {
+                expect(output).toBe([{ a: 'b' }]);
             });
     });
 });


### PR DESCRIPTION
When two files with the same names, but not in the same directory are
called, they should each have their own behaviour, not the one of the
first encountered file.

See [this issue](https://gitbucket.inist.fr/tdm/web-services/issues/1#comment-1381).