### PR TITLE
Customize npm runkit for @ezs/core

### DIFF
--- a/packages/core/examples/runkit-example.js
+++ b/packages/core/examples/runkit-example.js
@@ -1,0 +1,18 @@
+const ezs = require('@ezs/core');
+const from = require('from');
+
+const script = `
+[replace]
+path = id
+value = 1
+
+path = value
+value = This is a simple demo
+`;
+
+from([1])
+    .pipe(ezs('delegate', { script }))
+    .on('data', console.log)
+    .on('end', () => {
+        console.log('Stream\'s end.');
+    });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "access": "public"
   },
   "repository": "Inist-CNRS/ezs.git",
+  "runkitExampleFilename": "./examples/runkit-example.js",
   "scripts": {
     "#pretest": "npm run build",
     "build": "babel --root-mode upward src --out-dir lib",


### PR DESCRIPTION
See <https://blog.runkit.com/2015/10/28/npm-plus-runkit/>

Instead of having a simple import of the package, the `>_Try on RunKit` page could use an example.

Before:
![image](https://user-images.githubusercontent.com/595509/153610565-d325da12-7021-4b2b-92b3-b51be124e4ee.png)

After:
![image](https://user-images.githubusercontent.com/595509/153611142-253c7fdd-858a-4cc1-bb2c-067fe61e1ab1.png)