### PR TITLE
teeft: Improve sentence-tokenize

### DIFF
--- a/packages/teeft/src/sentence-tokenize.js
+++ b/packages/teeft/src/sentence-tokenize.js
@@ -2,7 +2,7 @@ const sentencesCutter = (input) => {
     if (!input || input.trim() === '') {
         return [];
     }
-    const regex = /(["'‘“'"[({⟨][^.?!]+[.?!]["'’”'"\])}⟩]|[^.?!]+[.?!\s]+)\s?/g;
+    const regex = /(["'‘“'"[({⟨]([A-Z]\.)?[^.?!]+[.?!]["'’”'"\])}⟩]|([A-Z]\.)?[^.?!]+[.?!\s]+)\s?/g;
     const tokens = input.match(regex);
 
     if (!tokens) {

--- a/packages/teeft/test/sentence-tokenize.spec.js
+++ b/packages/teeft/test/sentence-tokenize.spec.js
@@ -113,4 +113,28 @@ describe('sentence-tokenize', () => {
                 done();
             });
     });
+
+    it('should work with repeated species name', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            content: 'Canis Lupus est une espèce animale. ' +
+                     'C. Lupus réfère au même animal, et dans la deuxième phrase (qui va jusqu\'ici).',
+        }])
+            .pipe(ezs('TeeftSentenceTokenize'))
+            // .pipe(ezs('debug'))
+            .on('data', (chunk) => {
+                res = res.concat(chunk);
+            })
+            .on('end', () => {
+                expect(res).toEqual([{
+                    path: '/path/1',
+                    sentences: [
+                        'Canis Lupus est une espèce animale.',
+                        'C. Lupus réfère au même animal, et dans la deuxième phrase (qui va jusqu\'ici).',
+                    ],
+                }]);
+                done();
+            });
+    });
 });


### PR DESCRIPTION
In order to be able to segment phrases containing name species references.

Because a scientific species name (like _Canis lupus_) could be repeated in an abbreviated form (like _C. lupus_) later.