### PR TITLE
ezs/basics: add path parameter to TXTSentences

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,6 @@
         "import/no-extraneous-dependencies": "off",
         "no-param-reassign": ["error", { "props": false }],
         "semi": ["error", "always"],
-        "quotes": ["error", "single"]
+        "quotes": ["error", "single", { "avoidEscape": false }]
     }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-    "tabWidth": 4
+    "tabWidth": 4,
+    "singleQuote": true
 }

--- a/packages/basics/src/txt-sentences.js
+++ b/packages/basics/src/txt-sentences.js
@@ -10,7 +10,7 @@ const SENTENCE_ENDING = '.?!';
  * @returns {string[]}
  */
 const segmentSentences = (str) => {
-    const characters = str.split('');
+    const characters = Array.from(str);
     const sentences = characters
         .reduce(
             /*
@@ -51,7 +51,7 @@ const segmentSentences = (str) => {
             },
             [SENTENCE_INIT]
         )
-        .filter(sentence => sentence !== SENTENCE_INIT)
+        .filter((sentence) => sentence !== SENTENCE_INIT)
         .map((sentence) => sentence.trimStart());
     return sentences;
 };
@@ -63,10 +63,9 @@ const TXTSentences = (data, feed, ctx) => {
     const path = ctx.getParam('path', 'value');
     const value = get(data, path);
 
-    let str;
-    if (typeof value === 'string') {
-        str = value;
-    }
+    const str = Array.isArray(value)
+        ? value.map((item) => (typeof item === 'string' ? item : '')).join(' ')
+        : value;
     const sentences = str ? segmentSentences(str) : [];
 
     feed.write({ ...data, [path]: sentences });

--- a/packages/basics/test/txt-sentences.js
+++ b/packages/basics/test/txt-sentences.js
@@ -1,4 +1,5 @@
 import from from 'from';
+// @ts-ignore
 import ezs from '../../core/src';
 import ezsBasics from '../src';
 
@@ -6,130 +7,177 @@ ezs.use(ezsBasics);
 
 describe('TXTSentences', () => {
     it('should return an array', (done) => {
-        from([''])
+        let res = [];
+        from([{ value: '' }])
             .pipe(ezs('TXTSentences'))
             .on('data', (data) => {
-                expect(Array.isArray(data)).toBe(true);
-                expect(data).toStrictEqual([]);
+                res = [...res, data];
             })
             .on('end', () => {
+                expect(res).toStrictEqual([{ value: [] }]);
                 done();
             });
     });
 
     it('should generate two sentences', (done) => {
         let res = [];
-        from(['After all. These are two sentences.'])
+        from([{ value: 'After all. These are two sentences.' }])
             .pipe(ezs('TXTSentences'))
             .on('data', (data) => {
                 res = [...res, data];
             })
             .on('end', () => {
-                expect(res).toStrictEqual(['After all.', 'These are two sentences.']);
+                expect(res).toStrictEqual([
+                    { value: ['After all.', 'These are two sentences.'] },
+                ]);
+                done();
+            });
+    });
+
+    it('should take path parameter into account', (done) => {
+        let res = [];
+        from([{ other: 'After all. These are two sentences.' }])
+            .pipe(ezs('TXTSentences', { path: 'other' }))
+            .on('data', (data) => {
+                res = [...res, data];
+            })
+            .on('end', () => {
+                expect(res).toStrictEqual([
+                    { other: ['After all.', 'These are two sentences.'] },
+                ]);
+                done();
+            });
+    });
+
+    it('should generate three sentences', (done) => {
+        let res = [];
+        from([{ value: 'And now. Three sentences. Indeed.' }])
+            .pipe(ezs('TXTSentences'))
+            .on('data', (data) => {
+                res = [...res, data];
+            })
+            .on('end', () => {
+                expect(res).toStrictEqual([
+                    { value: ['And now.', 'Three sentences.', 'Indeed.'] },
+                ]);
                 done();
             });
     });
 
     it('should return an empty array when input is not a string', (done) => {
         let res = [];
-        from([{}])
+        from([{ value: {} }, { value: 1 }, { value: true }])
             .pipe(ezs('TXTSentences'))
             .on('data', (data) => {
                 res = [...res, data];
             })
             .on('end', () => {
-                expect(res).toStrictEqual([]);
-                done();
-            });
-    });
-
-    it('should generate two values from a Buffer', (done) => {
-        let res = [];
-        from([Buffer.from('Sentence 1. Sentence 2.')])
-            .pipe(ezs('TXTSentences'))
-            .on('data', (data) => {
-                res = [...res, data];
-            })
-            .on('end', () => {
-                expect(res).toStrictEqual(['Sentence 1.', 'Sentence 2.']);
-                done();
-            });
-    });
-
-    it('should generate from several chunks', (done) => {
-        let res = [];
-        from(['Senten', 'ce 1. Sent', 'ence 2.'])
-            .pipe(ezs('TXTSentences'))
-            .on('data', (data) => {
-                res = [...res, data];
-            })
-            .on('end', () => {
-                expect(res).toStrictEqual(['Sentence 1.', 'Sentence 2.']);
+                expect(res).toStrictEqual([
+                    { value: [] },
+                    { value: [] },
+                    { value: [] },
+                ]);
                 done();
             });
     });
 
     it('should generate two sentences with other endings', (done) => {
         let res = [];
-        from(['Is it? It is!'])
+        from([{ value: 'Is it? It is!' }])
             .pipe(ezs('TXTSentences'))
             .on('data', (data) => {
                 res = [...res, data];
             })
             .on('end', () => {
-                expect(res).toStrictEqual(['Is it?', 'It is!']);
+                expect(res).toStrictEqual([{ value: ['Is it?', 'It is!'] }]);
                 done();
             });
     });
 
     it('should not split initials in the middle of a sentence', (done) => {
         let res = [];
-        from(['My name is Bond, J. Bond.'])
+        from([{ value: 'My name is Bond, J. Bond.' }])
             .pipe(ezs('TXTSentences'))
             .on('data', (data) => {
                 res = [...res, data];
             })
             .on('end', () => {
-                expect(res).toStrictEqual(['My name is Bond, J. Bond.']);
+                expect(res).toStrictEqual([
+                    { value: ['My name is Bond, J. Bond.'] },
+                ]);
                 done();
             });
     });
 
     it('should not split initials at the beginning of a sentence', (done) => {
         let res = [];
-        from(['C. Norris, that means Chuck Norris.'])
+        from([{ value: 'C. Norris, that means Chuck Norris.' }])
             .pipe(ezs('TXTSentences'))
             .on('data', (data) => {
                 res = [...res, data];
             })
             .on('end', () => {
-                expect(res).toStrictEqual(['C. Norris, that means Chuck Norris.']);
+                expect(res).toStrictEqual([
+                    { value: ['C. Norris, that means Chuck Norris.'] },
+                ]);
+                done();
+            });
+    });
+
+    it('should return an array already segmented', (done) => {
+        let res = [];
+        from([{ value: ['Sentence 1.', 'Sentence 2.'] }])
+            .pipe(ezs('TXTSentences'))
+            .on('data', (data) => {
+                res = [...res, data];
+            })
+            .on('end', () => {
+                expect(res).toStrictEqual([
+                    { value: ['Sentence 1.', 'Sentence 2.'] },
+                ]);
+                done();
+            });
+    });
+
+    it('should segment again an array wrongly segmented', (done) => {
+        let res = [];
+        from([{ value: ['Sentence', '1. Sentence 2.'] }])
+            .pipe(ezs('TXTSentences'))
+            .on('data', (data) => {
+                res = [...res, data];
+            })
+            .on('end', () => {
+                expect(res).toStrictEqual([
+                    { value: ['Sentence 1.', 'Sentence 2.'] },
+                ]);
                 done();
             });
     });
 
     it.skip('should not split abbreviations in a sentence', (done) => {
         let res = [];
-        from(['Born in the U.S.A.'])
+        from([{ value: 'Born in the U.S.A.' }])
             .pipe(ezs('TXTSentences'))
             .on('data', (data) => {
                 res = [...res, data];
             })
             .on('end', () => {
-                expect(res).toStrictEqual(['Born in the U.S.A.']);
+                expect(res).toStrictEqual([{ value: ['Born in the U.S.A.'] }]);
                 done();
             });
     });
 
     it.skip('should not split abbreviations at the end of a sentence', (done) => {
         let res = [];
-        from(['Don\'t use T.N.T. inside buildings.'])
+        from([{ value: 'Don\'t use T.N.T. inside buildings.' }])
             .pipe(ezs('TXTSentences'))
             .on('data', (data) => {
                 res = [...res, data];
             })
             .on('end', () => {
-                expect(res).toStrictEqual(['Don\'t use T.N.T. inside buildings.']);
+                expect(res).toStrictEqual([
+                    { value: ['Don\'t use T.N.T. inside buildings.'] },
+                ]);
                 done();
             });
     });


### PR DESCRIPTION
`TXTSentences` wasn't usable: it took a string (or a buffer) as an entry, like `TXTParse`.

That was not the idea: we should be able to use it without tweaking the input structure (and losing fields).

> **Warning**: this is a breaking change, because first version of `TXTSentences` won't work any more.