### PR TITLE
Teeft add remove terms statements

### DIFF
--- a/docs/plugin-teeft.md
+++ b/docs/plugin-teeft.md
@@ -129,6 +129,54 @@ tags = ADJ
   }, ...
  ] }, ... ]
 
+[TeeftRemoveShortTerms]
+
+--> [  { path, terms:  [
+  {
+    term: "monoterm",
+    tag: [ "tag", ...],
+    frequency,
+    length
+  },
+  {
+    term: "multiterm",
+    frequency,
+    length
+  }, ...
+ ] }, ... ]
+
+[TeeftRemoveLongTerms]
+
+--> [  { path, terms:  [
+  {
+    term: "monoterm",
+    tag: [ "tag", ...],
+    frequency,
+    length
+  },
+  {
+    term: "multiterm",
+    frequency,
+    length
+  }, ...
+ ] }, ... ]
+
+[TeeftRemoveWeirdTerms]
+
+--> [  { path, terms:  [
+  {
+    term: "monoterm",
+    tag: [ "tag", ...],
+    frequency,
+    length
+  },
+  {
+    term: "multiterm",
+    frequency,
+    length
+  }, ...
+ ] }, ... ]
+
 [TeeftSumUpFrequencies]
 
 --> [  { path, terms:  [

--- a/docs/plugin-teeft.md
+++ b/docs/plugin-teeft.md
@@ -217,7 +217,10 @@ indent = true
 -   [TeeftGetFilesContent](#teeftgetfilescontent)
 -   [TeeftListFiles](#teeftlistfiles)
 -   [TeeftNaturalTag](#teeftnaturaltag)
+-   [TeeftRemoveLongTerms](#teeftremovelongterms)
 -   [TeeftRemoveNumbers](#teeftremovenumbers)
+-   [TeeftRemoveShortTerms](#teeftremoveshortterms)
+-   [TeeftRemoveWeirdTerms](#teeftremoveweirdterms)
 -   [TeeftSentenceTokenize](#teeftsentencetokenize)
 -   [TeeftSpecificity](#teeftspecificity)
 -   [TeeftStopWords](#teeftstopwords)
@@ -360,12 +363,91 @@ Yield an array of documents (objects:
  }]
 ```
 
+### TeeftRemoveLongTerms
+
+Remove long terms from documents (longer than 50 characters).
+Documents must have a `terms` key, containing an array of objects with a
+`term` key of type string..
+
+Yields an array of documents with the same structure.
+
+Input:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "this very long term should really be removed 678901" },
+            { "term": "abcd" }]
+}]
+```
+
+Output:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "abcd" }]
+}]
+```
+
 ### TeeftRemoveNumbers
 
 Remove numbers from the terms of documents (objects `{ path, terms: [{ term,
 ...}] }`).
 
 Yields an array of documents with the same structure.
+
+### TeeftRemoveShortTerms
+
+Remove short terms from documents (shorter than 3 characters).
+Documents must have a `terms` key, containing an array of objects with a
+`term` key of type string..
+
+Yields an array of documents with the same structure.
+
+Input:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "a" }, { "term": "abcd" }]
+}]
+```
+
+Output:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "abcd" }]
+}]
+```
+
+### TeeftRemoveWeirdTerms
+
+Remove terms with too much non-alphanumeric characters.
+Documents must have a `terms` key, containing an array of objects with a
+`term` key of type string..
+
+Yields an array of documents with the same structure.
+
+Input:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "αβɣδ" }, { "term": "abcd" }]
+}]
+```
+
+Output:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "abcd" }]
+}]
+```
 
 ### TeeftSentenceTokenize
 

--- a/docs/plugin-teeft.md
+++ b/docs/plugin-teeft.md
@@ -3,7 +3,7 @@
 ## Présentation
 
 Ce plugin propose une série d'instructions pour extraire des mots-clés d'un
-texte français, ou en anglais en utilisant l'algorithme Teeft.
+texte français ou anglais en utilisant l'algorithme Teeft.
 
 C'est le paquet officiel qui fait suite à l'expérimentation
 [ezs-teeftfr](https://github.com/istex/node-ezs-teeftfr).

--- a/packages/teeft/README.md
+++ b/packages/teeft/README.md
@@ -129,6 +129,54 @@ tags = ADJ
   }, ...
  ] }, ... ]
 
+[TeeftRemoveShortTerms]
+
+--> [  { path, terms:  [
+  {
+    term: "monoterm",
+    tag: [ "tag", ...],
+    frequency,
+    length
+  },
+  {
+    term: "multiterm",
+    frequency,
+    length
+  }, ...
+ ] }, ... ]
+
+[TeeftRemoveLongTerms]
+
+--> [  { path, terms:  [
+  {
+    term: "monoterm",
+    tag: [ "tag", ...],
+    frequency,
+    length
+  },
+  {
+    term: "multiterm",
+    frequency,
+    length
+  }, ...
+ ] }, ... ]
+
+[TeeftRemoveWeirdTerms]
+
+--> [  { path, terms:  [
+  {
+    term: "monoterm",
+    tag: [ "tag", ...],
+    frequency,
+    length
+  },
+  {
+    term: "multiterm",
+    frequency,
+    length
+  }, ...
+ ] }, ... ]
+
 [TeeftSumUpFrequencies]
 
 --> [  { path, terms:  [

--- a/packages/teeft/README.md
+++ b/packages/teeft/README.md
@@ -217,7 +217,10 @@ indent = true
 -   [TeeftGetFilesContent](#teeftgetfilescontent)
 -   [TeeftListFiles](#teeftlistfiles)
 -   [TeeftNaturalTag](#teeftnaturaltag)
+-   [TeeftRemoveLongTerms](#teeftremovelongterms)
 -   [TeeftRemoveNumbers](#teeftremovenumbers)
+-   [TeeftRemoveShortTerms](#teeftremoveshortterms)
+-   [TeeftRemoveWeirdTerms](#teeftremoveweirdterms)
 -   [TeeftSentenceTokenize](#teeftsentencetokenize)
 -   [TeeftSpecificity](#teeftspecificity)
 -   [TeeftStopWords](#teeftstopwords)
@@ -360,12 +363,91 @@ Yield an array of documents (objects:
  }]
 ```
 
+### TeeftRemoveLongTerms
+
+Remove long terms from documents (longer than 50 characters).
+Documents must have a `terms` key, containing an array of objects with a
+`term` key of type string..
+
+Yields an array of documents with the same structure.
+
+Input:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "this very long term should really be removed 678901" },
+            { "term": "abcd" }]
+}]
+```
+
+Output:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "abcd" }]
+}]
+```
+
 ### TeeftRemoveNumbers
 
 Remove numbers from the terms of documents (objects `{ path, terms: [{ term,
 ...}] }`).
 
 Yields an array of documents with the same structure.
+
+### TeeftRemoveShortTerms
+
+Remove short terms from documents (shorter than 3 characters).
+Documents must have a `terms` key, containing an array of objects with a
+`term` key of type string..
+
+Yields an array of documents with the same structure.
+
+Input:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "a" }, { "term": "abcd" }]
+}]
+```
+
+Output:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "abcd" }]
+}]
+```
+
+### TeeftRemoveWeirdTerms
+
+Remove terms with too much non-alphanumeric characters.
+Documents must have a `terms` key, containing an array of objects with a
+`term` key of type string..
+
+Yields an array of documents with the same structure.
+
+Input:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "αβɣδ" }, { "term": "abcd" }]
+}]
+```
+
+Output:
+
+```json
+[{
+  "path": "/path/to/file.txt",
+  "terms": [{ "term": "abcd" }]
+}]
+```
 
 ### TeeftSentenceTokenize
 

--- a/packages/teeft/README.md
+++ b/packages/teeft/README.md
@@ -3,7 +3,7 @@
 ## Présentation
 
 Ce plugin propose une série d'instructions pour extraire des mots-clés d'un
-texte français, ou en anglais en utilisant l'algorithme Teeft.
+texte français ou anglais en utilisant l'algorithme Teeft.
 
 C'est le paquet officiel qui fait suite à l'expérimentation
 [ezs-teeftfr](https://github.com/istex/node-ezs-teeftfr).
@@ -210,24 +210,41 @@ indent = true
 
 #### Table of Contents
 
--   [TeeftExtractTerms](#teeftextractterms)
--   [TeeftFilterMonoFreq](#teeftfiltermonofreq)
--   [TeeftFilterMultiSpec](#teeftfiltermultispec)
--   [TeeftFilterTags](#teeftfiltertags)
--   [TeeftGetFilesContent](#teeftgetfilescontent)
--   [TeeftListFiles](#teeftlistfiles)
--   [TeeftNaturalTag](#teeftnaturaltag)
--   [TeeftRemoveNumbers](#teeftremovenumbers)
--   [TeeftSentenceTokenize](#teeftsentencetokenize)
--   [TeeftSpecificity](#teeftspecificity)
--   [TeeftStopWords](#teeftstopwords)
--   [TeeftSumUpFrequencies](#teeftsumupfrequencies)
--   [TeeftTokenize](#teefttokenize)
--   [TeeftToLowerCase](#teefttolowercase)
+- [teeft](#teeft)
+  - [Présentation](#présentation)
+    - [Bibliographie](#bibliographie)
+  - [Installation](#installation)
+  - [Flux](#flux)
+  - [usage](#usage)
+      - [Table of Contents](#table-of-contents)
+    - [TeeftExtractTerms](#teeftextractterms)
+      - [Parameters](#parameters)
+      - [Examples](#examples)
+    - [TeeftFilterMonoFreq](#teeftfiltermonofreq)
+      - [Parameters](#parameters-1)
+    - [TeeftFilterMultiSpec](#teeftfiltermultispec)
+    - [TeeftFilterTags](#teeftfiltertags)
+      - [Parameters](#parameters-2)
+    - [TeeftGetFilesContent](#teeftgetfilescontent)
+    - [TeeftListFiles](#teeftlistfiles)
+      - [Parameters](#parameters-3)
+    - [TeeftNaturalTag](#teeftnaturaltag)
+      - [Parameters](#parameters-4)
+      - [Examples](#examples-1)
+    - [TeeftRemoveNumbers](#teeftremovenumbers)
+    - [TeeftSentenceTokenize](#teeftsentencetokenize)
+    - [TeeftSpecificity](#teeftspecificity)
+      - [Parameters](#parameters-5)
+    - [TeeftStopWords](#teeftstopwords)
+      - [Parameters](#parameters-6)
+    - [TeeftSumUpFrequencies](#teeftsumupfrequencies)
+    - [TeeftTokenize](#teefttokenize)
+    - [TeeftToLowerCase](#teefttolowercase)
+      - [Parameters](#parameters-7)
 
 ### TeeftExtractTerms
 
--   **See: <https://github.com/istex/sisyphe/blob/master/src/worker/teeft/lib/termextractor.js>
+- **See: <https://github.com/istex/sisyphe/blob/master/src/worker/teeft/lib/termextractor.js>
     **
 
 Take an array of objects `{ path, sentences: [token, tag: ["tag"]]}`. Regroup
@@ -239,10 +256,10 @@ time. `lang` is enough to set `nounTag` and `adjTag`.
 
 #### Parameters
 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the terms to extract (`en` or
+- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the terms to extract (`en` or
     `fr`) (optional, default `'fr'`)
--   `nounTag` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** noun tag (`NOM` in French, `NN` in English) (optional, default `'NOM'`)
--   `adjTag` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** adjective tag (`ADJ` in French, `JJ` in
+- `nounTag` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** noun tag (`NOM` in French, `NN` in English) (optional, default `'NOM'`)
+- `adjTag` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** adjective tag (`ADJ` in French, `JJ` in
     English) (optional, default `'ADJ'`)
 
 #### Examples
@@ -282,9 +299,9 @@ automatically computed from the number of tokens in the document.
 
 #### Parameters
 
--   `multiLimit` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** threshold for being a multiterm (in tokens
+- `multiLimit` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** threshold for being a multiterm (in tokens
     number) (optional, default `2`)
--   `minFrequency` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** minimal frequency to be taken as a
+- `minFrequency` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** minimal frequency to be taken as a
     frequent term (optional, default `7`)
 
 ### TeeftFilterMultiSpec
@@ -298,8 +315,8 @@ Filter the text in input, by keeping only adjectives and names
 
 #### Parameters
 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Language to set tags (`en` or `fr`)
--   `tags` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Tags to keep (ex: `ADJ`, `NOM`)
+- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Language to set tags (`en` or `fr`)
+- `tags` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Tags to keep (ex: `ADJ`, `NOM`)
 
 ### TeeftGetFilesContent
 
@@ -315,7 +332,7 @@ file paths matching the pattern in the directories from the input.
 
 #### Parameters
 
--   `pattern` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** pattern for files (ex: "\*.txt") (optional, default `"*"`)
+- `pattern` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** pattern for files (ex: "\*.txt") (optional, default `"*"`)
 
 Returns **\[[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)]** an array of file paths
 
@@ -343,7 +360,7 @@ Yield an array of documents (objects:
 
 #### Parameters
 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the text to tag (possible values: `fr`, `en`) (optional, default `'en'`)
+- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the text to tag (possible values: `fr`, `en`) (optional, default `'en'`)
 
 #### Examples
 
@@ -387,9 +404,9 @@ Can also sort the objects according to their specificity, when `sort` is
 
 #### Parameters
 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language to take into account (optional, default `"en"`)
--   `filter` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** filter below average specificity (optional, default `true`)
--   `sort` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** sort objects according to their specificity (optional, default `false`)
+- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language to take into account (optional, default `"en"`)
+- `filter` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** filter below average specificity (optional, default `true`)
+- `sort` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** sort objects according to their specificity (optional, default `false`)
 
 ### TeeftStopWords
 
@@ -397,7 +414,7 @@ Filter the text in input, by removing stopwords in token
 
 #### Parameters
 
--   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the stopwords (`en` or `fr`) (optional, default `'en'`)
+- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the stopwords (`en` or `fr`) (optional, default `'en'`)
 
 ### TeeftSumUpFrequencies
 
@@ -405,7 +422,7 @@ Sums up the frequencies of identical lemmas from different chunks.
 
 ### TeeftTokenize
 
--   **See: <http://yomguithereal.github.io/talisman/tokenizers/words>
+- **See: <http://yomguithereal.github.io/talisman/tokenizers/words>
     **
 
 Extract tokens from an array of documents (objects `{ path, sentences: [] }`).
@@ -421,4 +438,4 @@ Transform strings to lower case.
 
 #### Parameters
 
--   `path` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** path to the property to modify (optional, default `[]`)
+- `path` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** path to the property to modify (optional, default `[]`)

--- a/packages/teeft/README.md
+++ b/packages/teeft/README.md
@@ -210,41 +210,24 @@ indent = true
 
 #### Table of Contents
 
-- [teeft](#teeft)
-  - [Présentation](#présentation)
-    - [Bibliographie](#bibliographie)
-  - [Installation](#installation)
-  - [Flux](#flux)
-  - [usage](#usage)
-      - [Table of Contents](#table-of-contents)
-    - [TeeftExtractTerms](#teeftextractterms)
-      - [Parameters](#parameters)
-      - [Examples](#examples)
-    - [TeeftFilterMonoFreq](#teeftfiltermonofreq)
-      - [Parameters](#parameters-1)
-    - [TeeftFilterMultiSpec](#teeftfiltermultispec)
-    - [TeeftFilterTags](#teeftfiltertags)
-      - [Parameters](#parameters-2)
-    - [TeeftGetFilesContent](#teeftgetfilescontent)
-    - [TeeftListFiles](#teeftlistfiles)
-      - [Parameters](#parameters-3)
-    - [TeeftNaturalTag](#teeftnaturaltag)
-      - [Parameters](#parameters-4)
-      - [Examples](#examples-1)
-    - [TeeftRemoveNumbers](#teeftremovenumbers)
-    - [TeeftSentenceTokenize](#teeftsentencetokenize)
-    - [TeeftSpecificity](#teeftspecificity)
-      - [Parameters](#parameters-5)
-    - [TeeftStopWords](#teeftstopwords)
-      - [Parameters](#parameters-6)
-    - [TeeftSumUpFrequencies](#teeftsumupfrequencies)
-    - [TeeftTokenize](#teefttokenize)
-    - [TeeftToLowerCase](#teefttolowercase)
-      - [Parameters](#parameters-7)
+-   [TeeftExtractTerms](#teeftextractterms)
+-   [TeeftFilterMonoFreq](#teeftfiltermonofreq)
+-   [TeeftFilterMultiSpec](#teeftfiltermultispec)
+-   [TeeftFilterTags](#teeftfiltertags)
+-   [TeeftGetFilesContent](#teeftgetfilescontent)
+-   [TeeftListFiles](#teeftlistfiles)
+-   [TeeftNaturalTag](#teeftnaturaltag)
+-   [TeeftRemoveNumbers](#teeftremovenumbers)
+-   [TeeftSentenceTokenize](#teeftsentencetokenize)
+-   [TeeftSpecificity](#teeftspecificity)
+-   [TeeftStopWords](#teeftstopwords)
+-   [TeeftSumUpFrequencies](#teeftsumupfrequencies)
+-   [TeeftTokenize](#teefttokenize)
+-   [TeeftToLowerCase](#teefttolowercase)
 
 ### TeeftExtractTerms
 
-- **See: <https://github.com/istex/sisyphe/blob/master/src/worker/teeft/lib/termextractor.js>
+-   **See: <https://github.com/istex/sisyphe/blob/master/src/worker/teeft/lib/termextractor.js>
     **
 
 Take an array of objects `{ path, sentences: [token, tag: ["tag"]]}`. Regroup
@@ -256,10 +239,10 @@ time. `lang` is enough to set `nounTag` and `adjTag`.
 
 #### Parameters
 
-- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the terms to extract (`en` or
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the terms to extract (`en` or
     `fr`) (optional, default `'fr'`)
-- `nounTag` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** noun tag (`NOM` in French, `NN` in English) (optional, default `'NOM'`)
-- `adjTag` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** adjective tag (`ADJ` in French, `JJ` in
+-   `nounTag` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** noun tag (`NOM` in French, `NN` in English) (optional, default `'NOM'`)
+-   `adjTag` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** adjective tag (`ADJ` in French, `JJ` in
     English) (optional, default `'ADJ'`)
 
 #### Examples
@@ -299,9 +282,9 @@ automatically computed from the number of tokens in the document.
 
 #### Parameters
 
-- `multiLimit` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** threshold for being a multiterm (in tokens
+-   `multiLimit` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** threshold for being a multiterm (in tokens
     number) (optional, default `2`)
-- `minFrequency` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** minimal frequency to be taken as a
+-   `minFrequency` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** minimal frequency to be taken as a
     frequent term (optional, default `7`)
 
 ### TeeftFilterMultiSpec
@@ -315,8 +298,8 @@ Filter the text in input, by keeping only adjectives and names
 
 #### Parameters
 
-- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Language to set tags (`en` or `fr`)
-- `tags` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Tags to keep (ex: `ADJ`, `NOM`)
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Language to set tags (`en` or `fr`)
+-   `tags` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Tags to keep (ex: `ADJ`, `NOM`)
 
 ### TeeftGetFilesContent
 
@@ -332,7 +315,7 @@ file paths matching the pattern in the directories from the input.
 
 #### Parameters
 
-- `pattern` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** pattern for files (ex: "\*.txt") (optional, default `"*"`)
+-   `pattern` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** pattern for files (ex: "\*.txt") (optional, default `"*"`)
 
 Returns **\[[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)]** an array of file paths
 
@@ -360,7 +343,7 @@ Yield an array of documents (objects:
 
 #### Parameters
 
-- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the text to tag (possible values: `fr`, `en`) (optional, default `'en'`)
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the text to tag (possible values: `fr`, `en`) (optional, default `'en'`)
 
 #### Examples
 
@@ -404,9 +387,9 @@ Can also sort the objects according to their specificity, when `sort` is
 
 #### Parameters
 
-- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language to take into account (optional, default `"en"`)
-- `filter` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** filter below average specificity (optional, default `true`)
-- `sort` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** sort objects according to their specificity (optional, default `false`)
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language to take into account (optional, default `"en"`)
+-   `filter` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** filter below average specificity (optional, default `true`)
+-   `sort` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** sort objects according to their specificity (optional, default `false`)
 
 ### TeeftStopWords
 
@@ -414,7 +397,7 @@ Filter the text in input, by removing stopwords in token
 
 #### Parameters
 
-- `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the stopwords (`en` or `fr`) (optional, default `'en'`)
+-   `lang` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** language of the stopwords (`en` or `fr`) (optional, default `'en'`)
 
 ### TeeftSumUpFrequencies
 
@@ -422,7 +405,7 @@ Sums up the frequencies of identical lemmas from different chunks.
 
 ### TeeftTokenize
 
-- **See: <http://yomguithereal.github.io/talisman/tokenizers/words>
+-   **See: <http://yomguithereal.github.io/talisman/tokenizers/words>
     **
 
 Extract tokens from an array of documents (objects `{ path, sentences: [] }`).
@@ -438,4 +421,4 @@ Transform strings to lower case.
 
 #### Parameters
 
-- `path` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** path to the property to modify (optional, default `[]`)
+-   `path` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** path to the property to modify (optional, default `[]`)

--- a/packages/teeft/examples/fr-remove-weird-terms.ini
+++ b/packages/teeft/examples/fr-remove-weird-terms.ini
@@ -1,0 +1,39 @@
+#!/usr/bin/env ezs
+
+# Supprime les termes avec un haut taux de caractères non alphanumériques.
+
+# `@ezs/basics` doit être installé aussi pour que ce script fonctionne.
+
+# echo '["examples/data/artificial.txt"]' | npx ezs ./examples/fr-filter-tags.ini
+
+# > Remarque: utilisez `fx` pour parcourir interactivement le JSON produit.
+# > <https://github.com/antonmedv/fx>
+
+[use]
+plugin = teeft
+plugin = basics
+
+[JSONParse]
+
+[TeeftGetFilesContent]
+
+[TeeftToLowerCase]
+path = content
+
+[TeeftSentenceTokenize]
+
+[TeeftTokenize]
+
+[TeeftNaturalTag]
+lang = fr
+
+[TeeftExtractTerms]
+lang = fr
+
+[TeeftFilterTags]
+lang = fr
+
+[TeeftRemoveWeirdTerms]
+
+[dump]
+indent = true

--- a/packages/teeft/src/index.js
+++ b/packages/teeft/src/index.js
@@ -5,7 +5,10 @@ import TeeftFilterTags from './filter-tags';
 import TeeftGetFilesContent from './get-files-content';
 import TeeftListFiles from './list-files';
 import TeeftNaturalTag from './natural-tag';
+import TeeftRemoveLongTerms from './remove-long-terms';
 import TeeftRemoveNumbers from './remove-numbers';
+import TeeftRemoveShortTerms from './remove-short-terms';
+import TeeftRemoveWeirdTerms from './remove-weird-terms';
 import TeeftSentenceTokenize from './sentence-tokenize';
 import TeeftSpecificity from './specificity';
 import TeeftStopWords from './stop-words';
@@ -21,7 +24,10 @@ const funcs = {
     TeeftGetFilesContent,
     TeeftListFiles,
     TeeftNaturalTag,
+    TeeftRemoveLongTerms,
     TeeftRemoveNumbers,
+    TeeftRemoveShortTerms,
+    TeeftRemoveWeirdTerms,
     TeeftSentenceTokenize,
     TeeftSpecificity,
     TeeftStopWords,

--- a/packages/teeft/src/remove-long-terms.js
+++ b/packages/teeft/src/remove-long-terms.js
@@ -1,0 +1,51 @@
+import { gte, length, pipe, prop } from 'ramda';
+
+export const termIsNotLong = pipe(
+    prop('term'),
+    length,
+    gte(50)
+);
+
+/**
+ * Remove long terms from documents (longer than 50 characters).
+ * Documents must have a `terms` key, containing an array of objects with a
+ * `term` key of type string..
+ *
+ * Yields an array of documents with the same structure.
+ *
+ * Input:
+ *
+ * ```json
+ * [{
+ *   "path": "/path/to/file.txt",
+ *   "terms": [{ "term": "this very long term should really be removed 678901" },
+ *             { "term": "abcd" }]
+ * }]
+ * ```
+ *
+ * Output:
+ *
+ * ```json
+ * [{
+ *   "path": "/path/to/file.txt",
+ *   "terms": [{ "term": "abcd" }]
+ * }]
+ * ```
+ *
+ * @export
+ * @name TeeftRemoveLongTerms
+ */
+export default function TeeftRemoveLongTerms(data, feed, ctx) {
+    if (ctx.isLast()) {
+        return feed.close();
+    }
+
+    const docIn = data;
+
+    const docOut = {
+        ...docIn,
+        terms: docIn.terms.filter(termIsNotLong),
+    };
+    feed.write(docOut);
+    feed.end();
+}

--- a/packages/teeft/src/remove-short-terms.js
+++ b/packages/teeft/src/remove-short-terms.js
@@ -1,0 +1,50 @@
+import { lt, length, pipe, prop } from 'ramda';
+
+export const termIsNotShort = pipe(
+    prop('term'),
+    length,
+    lt(2)
+);
+
+/**
+ * Remove short terms from documents (shorter than 3 characters).
+ * Documents must have a `terms` key, containing an array of objects with a
+ * `term` key of type string..
+ *
+ * Yields an array of documents with the same structure.
+ *
+ * Input:
+ *
+ * ```json
+ * [{
+ *   "path": "/path/to/file.txt",
+ *   "terms": [{ "term": "a" }, { "term": "abcd" }]
+ * }]
+ * ```
+ *
+ * Output:
+ *
+ * ```json
+ * [{
+ *   "path": "/path/to/file.txt",
+ *   "terms": [{ "term": "abcd" }]
+ * }]
+ * ```
+ *
+ * @export
+ * @name TeeftRemoveShortTerms
+ */
+export default function TeeftRemoveShortTerms(data, feed, ctx) {
+    if (ctx.isLast()) {
+        return feed.close();
+    }
+
+    const docIn = data;
+
+    const docOut = {
+        ...docIn,
+        terms: docIn.terms.filter(termIsNotShort),
+    };
+    feed.write(docOut);
+    feed.end();
+}

--- a/packages/teeft/src/remove-weird-terms.js
+++ b/packages/teeft/src/remove-weird-terms.js
@@ -1,0 +1,52 @@
+import { lte, pipe, prop } from 'ramda';
+
+const getAlphaNumericRatio = (term) => term.replace(/[^a-zA-Z0-9]/g, '').length / term.length;
+
+export const termIsNotWeird = pipe(
+    prop('term'),
+    getAlphaNumericRatio,
+    lte(0.5)
+);
+
+/**
+ * Remove terms with too much non-alphanumeric characters.
+ * Documents must have a `terms` key, containing an array of objects with a
+ * `term` key of type string..
+ *
+ * Yields an array of documents with the same structure.
+ *
+ * Input:
+ *
+ * ```json
+ * [{
+ *   "path": "/path/to/file.txt",
+ *   "terms": [{ "term": "αβɣδ" }, { "term": "abcd" }]
+ * }]
+ * ```
+ *
+ * Output:
+ *
+ * ```json
+ * [{
+ *   "path": "/path/to/file.txt",
+ *   "terms": [{ "term": "abcd" }]
+ * }]
+ * ```
+ *
+ * @export
+ * @name TeeftRemoveWeirdTerms
+ */
+export default function TeeftRemoveWeirdTerms(data, feed, ctx) {
+    if (ctx.isLast()) {
+        return feed.close();
+    }
+
+    const docIn = data;
+
+    const docOut = {
+        ...docIn,
+        terms: docIn.terms.filter(termIsNotWeird),
+    };
+    feed.write(docOut);
+    feed.end();
+}

--- a/packages/teeft/test/remove-long-terms.spec.js
+++ b/packages/teeft/test/remove-long-terms.spec.js
@@ -1,0 +1,178 @@
+import from from 'from';
+// @ts-ignore
+import ezs from '../../core/src';
+import statements from '../src';
+
+ezs.use(statements);
+
+describe('remove long terms', () => {
+    it('should not remove 50-character long terms', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: 'this very long term should really be removed 67890' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveLongTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(8);
+                done();
+            });
+    });
+
+    it('should remove 51-character long terms', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: 'this very long term should really be removed 678901' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveLongTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove 51-character long terms', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: 'this very long term should really be removed 678901' },
+                { frequency: 78, length: 1, tag: [], term: 'this second very long term should really be removed' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveLongTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove 51-character long term not at the beginning', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 78, length: 1, tag: [], term: 'this very long term should really be removed 678901' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveLongTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove 51-character long term at the end', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+                { frequency: 78, length: 1, tag: [], term: 'this very long term should really be removed 678901' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveLongTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove terms longer than 51 characters', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+                { frequency: 78, length: 1, tag: [], term: 'this very long term should really be removed 6789012345' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveLongTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+});

--- a/packages/teeft/test/remove-short-terms.spec.js
+++ b/packages/teeft/test/remove-short-terms.spec.js
@@ -1,0 +1,178 @@
+import from from 'from';
+// @ts-ignore
+import ezs from '../../core/src';
+import statements from '../src';
+
+ezs.use(statements);
+
+describe('remove short terms', () => {
+    it('should remove 2-character long term', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: 'ab' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveShortTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should not remove 3-character long term', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: 'abc' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveShortTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(8);
+                done();
+            });
+    });
+
+    it('should remove 1-character long term', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: 'a' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveShortTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove 1-character long terms', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: 'a' },
+                { frequency: 7, length: 1, tag: [], term: 'b' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveShortTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove 1-character long term not at the beginning', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 78, length: 1, tag: [], term: 'a' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveShortTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove 1-character long term at the end', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+                { frequency: 78, length: 1, tag: [], term: 'a' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveShortTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+});

--- a/packages/teeft/test/remove-weird-terms.spec.js
+++ b/packages/teeft/test/remove-weird-terms.spec.js
@@ -1,0 +1,262 @@
+import from from 'from';
+// @ts-ignore
+import ezs from '../../core/src';
+import statements from '../src';
+
+ezs.use(statements);
+
+describe('remove weird terms', () => {
+    it('should remove term with only non-alphanumeric characters', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: '-?/§µ£ø' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveWeirdTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove terms with only non-alphanumeric characters', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: '-?/§µ£ø' },
+                { frequency: 7, length: 1, tag: [], term: '²&"~#{([-|`_\\ç^@)]=}' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveWeirdTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove 1-character long term not at the beginning', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 78, length: 1, tag: [], term: '-?/§µ£ø' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveWeirdTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should remove 1-character long term at the end', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+                { frequency: 78, length: 1, tag: [], term: '-?/§µ£ø' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveWeirdTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should not remove real French terms', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: 'ébouriffé' },
+                { frequency: 4, length: 1, tag: [], term: 'aidé' },
+                { frequency: 2, length: 1, tag: [], term: 'expertisé' },
+                { frequency: 29, length: 1, tag: [], term: 'créé' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveWeirdTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(8);
+                done();
+            });
+    });
+
+    it('should remove terms with only accented characters', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: 'éèçàù' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveWeirdTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+    it('should not remove terms with a low non-alphanumeric ratio', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: '123&' },
+                { frequency: 4, length: 1, tag: [], term: '12&é' },
+                { frequency: 2, length: 1, tag: [], term: 'expertisé' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveWeirdTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(8);
+                done();
+            });
+    });
+
+    it('should remove terms with a high non-alphanumeric ratio', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: '1&é~' },
+                { frequency: 4, length: 1, tag: [], term: '1234&é~"{(' },
+                { frequency: 2, length: 1, tag: [], term: 'expertisé' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveWeirdTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(6);
+                done();
+            });
+    });
+
+    it('should remove term too much spaces', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            terms: [
+                { frequency: 78, length: 1, tag: [], term: ' a b     c ?' },
+                { frequency: 4, length: 1, tag: [], term: 'aide' },
+                { frequency: 2, length: 1, tag: [], term: 'expertise' },
+                { frequency: 29, length: 1, tag: [], term: 'brevets' },
+                { frequency: 1, length: 1, tag: [], term: 'alignement' },
+                { frequency: 6, length: 1, tag: [], term: 'publications' },
+                { frequency: 11, length: 1, tag: [], term: 'scientifiques' },
+                { frequency: 1, length: 2, term: 'publications scientifiques' },
+            ]
+        }])
+            .pipe(ezs('TeeftRemoveWeirdTerms'))
+            .on('data', (data) => {
+                res = res.concat(data);
+            })
+            .on('error', done)
+            .on('end', () => {
+                expect(res).toHaveLength(1);
+                const { terms } = res[0];
+                expect(terms).toHaveLength(7);
+                done();
+            });
+    });
+
+});


### PR DESCRIPTION
Add several statements in `@ezs/teeft` to remove wrong terms:

- `TeeftRemoveShortTerms`: to remove too short terms (like `-`, or `o`)
- `TeeftRemoveLongTerms`: to remove too long terms (like chemical formulae, or garbage)
- `TeeftRemoveWeirdTerms`: to remove terms containing too much non alpha-numerical characters

See [[terms-extraction/teeft] termes inutilisables sur des corpus de chimie](https://gitbucket.inist.fr/tdm/web-services/issues/31).