### PR TITLE
refactor(storage): Replace cacache with sqlite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# EZS Project AGENTS.md
+
+## Project Overview
+
+This repository contains a JavaScript monorepo for the **EZS** project, a tool
+for processing data streams using a pipeline of instructions.  
+The project is managed with Lerna and Yarn workspaces.
+
+The core package, `@ezs/core`, provides a set of "native instructions" that
+can be used to build complex data processing pipelines. These instructions
+include functionalities for transforming, filtering, and routing data.  
+The project is designed to be extensible, with additional packages providing
+more specialized instructions.
+
+## Building and Running
+
+### Dependencies
+
+Install dependencies using Yarn:
+
+```bash
+yarn install
+```
+
+### Building
+
+Build all the packages:
+
+```bash
+yarn build
+```
+
+### Testing
+
+Run the test suite:
+
+```bash
+yarn test
+```
+
+This will run all tests in the monorepo.  
+To run tests for a specific package, you can use the `jest` command directly
+within the package's directory.
+
+### Running the CLI
+
+The `@ezs/core` package provides a command-line interface (CLI) for executing
+EZS scripts.
+
+```bash
+packages/core/bin/ezs <your-script.ini>
+```
+
+## Development Conventions
+
+* **Monorepo:** The project is a monorepo, with individual packages located in the `packages/` directory.
+* **Yarn Workspaces:** Yarn workspaces are used to manage dependencies across the monorepo.
+* **Yarn Workspaces:** Yarn workspaces are used to manage dependencies across the monorepo.
+* **Linting:** The project uses ESLint for code linting. You can run the linter with `yarn lint`.
+
+### Committing
+
+The project uses [Conventional Commits](https://www.conventionalcommits.org). This allows for automatic changelog generation.
+
+When committing, the scope of the commit should be the name of the package directory (`core`, `cli`, `basics`, etc.) or `root`.
+
+Example of a fix commit in `packages/core`:
+
+```bash
+git commit -m "fix(core): Fix a bug in the core package"
+```
+
+Example of a feature commit in `packages/foo`:
+
+```bash
+git commit -m "feat(foo): Add a new feature to the foo package"
+```
+
+### Lerna Workflows
+
+[Lerna](https://lerna.js.org/) is used to manage the monorepo.
+
+* **Creating a new package:** `npx lerna create @ezs/package`
+* **Adding a dependency to a package:** `npx lerna add <dependency> --scope=@ezs/package`
+* **Bootstrapping packages:** `npx lerna bootstrap`
+
+### Publishing
+
+To publish packages to npm, you must have the appropriate rights to the `@ezs` organization on npm.
+
+The publishing process is as follows:
+
+1. Ensure you are on the `master` branch.
+2. Run `npm run release:version` to version the packages.
+3. Run `npm run release:publish` to publish the packages to npm.
+
+### Documentation
+
+The `documentation.js` library is used to generate documentation from source code comments.
+
+To generate the documentation, run:
+
+```bash
+npx yarn run doc
+```

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -5,7 +5,7 @@
   "author": "Nicolas Thouvenin <nthouvenin@gmail.com>",
   "bugs": "https://github.com/Inist-CNRS/ezs/issues",
   "dependencies": {
-    "cacache": "^17.1.3",
+    "better-sqlite3": "^12.4.1",
     "lodash": "4.17.21",
     "lru-cache": "5.1.1",
     "make-dir": "3.1.0",

--- a/packages/storage/src/load.js
+++ b/packages/storage/src/load.js
@@ -41,7 +41,7 @@ export default async function load(data, feed) {
         }
         return feed.send(value);
     } catch(e) {
-        if (e.code === 'ENOENT') {
+        if (e.code === 'ENOENT' || e.message.includes('Key not found')) {
             debug('ezs:warn')(`uri not found (${uri}), item #${this.getIndex()} was ignored`, ezs.serializeError(e));
             if (target) {
                 set(data, target, undefined);

--- a/packages/storage/src/store.js
+++ b/packages/storage/src/store.js
@@ -3,12 +3,46 @@ import { join } from 'path';
 import pathExists from 'path-exists';
 import makeDir from 'make-dir';
 import LRU from 'lru-cache';
-import cacache from 'cacache';
+import Database from 'better-sqlite3';
 
 class AbstractStore {
-    constructor(ezs, handle) {
+    constructor(ezs, dbPath) {
         this.ezs = ezs;
-        this.handle = handle;
+        this.dbPath = dbPath;
+
+        // Initialize SQLite database
+        this.db = new Database(join(dbPath, 'store.db'));
+
+        // Initialize schema
+        const schema = `
+            CREATE TABLE IF NOT EXISTS store_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                key TEXT NOT NULL UNIQUE,
+                value TEXT NOT NULL,
+                score INTEGER DEFAULT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_store_entries_key ON store_entries(key);
+            CREATE INDEX IF NOT EXISTS idx_store_entries_score ON store_entries(score);
+
+            CREATE TRIGGER IF NOT EXISTS update_store_entries_timestamp
+                AFTER UPDATE ON store_entries
+            BEGIN
+                UPDATE store_entries SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+            END;
+        `;
+        this.db.exec(schema);
+
+        // Prepare statements for better performance
+        this.getStmt = this.db.prepare('SELECT value FROM store_entries WHERE key = ?');
+        this.putStmt = this.db.prepare('INSERT OR REPLACE INTO store_entries (key, value, score) VALUES (?, ?, ?)');
+        this.putWithScoreCheckStmt = this.db.prepare('SELECT score FROM store_entries WHERE key = ?');
+        this.getAllStmt = this.db.prepare('SELECT key, value FROM store_entries ORDER BY id');
+        this.deleteAllStmt = this.db.prepare('DELETE FROM store_entries');
+
+        // Initialize LRU cache if enabled
         if (ezs.settings.cacheEnable) {
             this.cache = new LRU(ezs.settings.cache);
         } else {
@@ -18,29 +52,68 @@ class AbstractStore {
 
     get(key) {
         const k = JSON.stringify(key);
-        const o = { memoize: this.cache };
-        return cacache.get(this.handle, k, o).then(({ data }) => JSON.parse(String(data)));
+
+        // Check cache first if enabled
+        if (this.cache && typeof this.cache === 'object' && 'get' in this.cache) {
+            const cached = this.cache.get(k);
+            if (cached) {
+                return Promise.resolve(JSON.parse(cached));
+            }
+        }
+
+        try {
+            const row = this.getStmt.get(k);
+            if (!row) {
+                throw new Error(`Key not found: ${k}`);
+            }
+
+            const value = JSON.parse(row.value);
+
+            // Cache the result if caching is enabled
+            if (this.cache && typeof this.cache === 'object' && 'set' in this.cache) {
+                this.cache.set(k, row.value);
+            }
+
+            return Promise.resolve(value);
+        } catch (error) {
+            return Promise.reject(error);
+        }
     }
 
     async put(key, value, score) {
         const k = JSON.stringify(key);
         const v = JSON.stringify(value);
-        if (!score) {
-            return cacache.put(this.handle, k, v);
-        }
-        const alreadyExist = await cacache.get.info(this.handle, k);
-        if (!alreadyExist ||
-            !alreadyExist.metadata ||
-            !alreadyExist.metadata.score ||
-            alreadyExist.metadata.score < score) {
-            const o = {
-                metadata: {
-                    score,
+
+        try {
+            if (!score) {
+                // Simple put without score checking
+                this.putStmt.run(k, v, null);
+
+                // Update cache if enabled
+                if (this.cache && typeof this.cache === 'object' && 'set' in this.cache) {
+                    this.cache.set(k, v);
                 }
-            };
-            return cacache.put(this.handle, k, v, o);
+
+                return Promise.resolve(true);
+            }
+
+            // Check existing score if score is provided
+            const existing = this.putWithScoreCheckStmt.get(k);
+            if (!existing || !existing.score || existing.score < score) {
+                this.putStmt.run(k, v, score);
+
+                // Update cache if enabled
+                if (this.cache && typeof this.cache === 'object' && 'set' in this.cache) {
+                    this.cache.set(k, v);
+                }
+
+                return Promise.resolve(true);
+            }
+
+            return Promise.resolve(true);
+        } catch (error) {
+            return Promise.reject(error);
         }
-        return Promise.resolve(true);
     }
 
     stream() {
@@ -58,31 +131,71 @@ class AbstractStore {
     }
 
     cast() {
-        return cacache.ls.stream(this.handle).pipe(this.ezs( async (data, feed, ctx) => {
+        const { Readable } = require('stream');
+
+        // Create a readable stream that emits all entries
+        const readable = new Readable({ objectMode: true });
+
+        let rows;
+        try {
+            rows = this.getAllStmt.all();
+        } catch (error) {
+            readable.destroy(error);
+            return readable;
+        }
+
+        let index = 0;
+
+        readable._read = () => {
+            if (index < rows.length) {
+                const row = rows[index++];
+                try {
+                    const entry = {
+                        id: JSON.parse(row.key),
+                        value: JSON.parse(row.value),
+                    };
+                    readable.push(entry);
+                } catch (e) {
+                    readable.destroy(e);
+                }
+            } else {
+                readable.push(null); // End of stream
+            }
+        };
+
+        return readable.pipe(this.ezs(async (data, feed, ctx) => {
             if (ctx.isLast()) {
                 return feed.close();
             }
-            const { key, integrity } = data;
-            try {
-                const value = await cacache.get.byDigest(this.handle, integrity);
-                return feed.send({
-                    id: JSON.parse(key),
-                    value: JSON.parse(value),
-                });
-            }
-            catch (e) {
-                return feed.end();
-            }
+            return feed.send(data);
         }));
     }
 
     reset() {
-        return cacache.rm.all(this.handle);
+        try {
+            this.deleteAllStmt.run();
+
+            // Clear cache if enabled
+            if (this.cache && typeof this.cache === 'object' && 'reset' in this.cache) {
+                this.cache.reset();
+            }
+
+            return Promise.resolve(true);
+        } catch (error) {
+            return Promise.reject(error);
+        }
     }
 
     close() {
-        delete this.handle;
-        return Promise.resolve(true);
+        try {
+            if (this.db) {
+                this.db.close();
+                this.db = null;
+            }
+            return Promise.resolve(true);
+        } catch (error) {
+            return Promise.reject(error);
+        }
     }
 }
 


### PR DESCRIPTION
Le paquet `@ezs/storage` génère trop de fichiers (à tel point qu’ezmaster provoque une erreur de Garbage Collector en essayant de calculer la taille totale de tous ces fichiers pour une instance de [loterre-resolvers](https://github.com/Inist-CNRS/web-services/tree/70f110e0f56d463df81107ac32f4fa4a844e0b9d/services/loterre-resolvers)).

Il utilise actuellement `cacache`, et il vaudrait sans doute mieux utiliser sqlite qui ne génère qu’un seul fichier contenant données et index.
